### PR TITLE
fix(deploy): use official GitHub Pages actions with default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+
 jobs:
   deploy_gh_pages:
     runs-on: ubuntu-latest
@@ -13,7 +16,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          persist-credentials: false
           fetch-depth: 0
 
       - name: Install pnpm
@@ -37,5 +39,6 @@ jobs:
       - name: GitHub Pages Deploy
         uses: peaceiris/actions-gh-pages@v4
         with:
-          personal_token: ${{ secrets.PERSONAL_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
+          publish_branch: gh-pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -42,9 +40,6 @@ jobs:
       - name: Build UI
         run: pnpm run build
 
-      - name: Configure Pages
-        uses: actions/configure-pages@v6
-
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5
         with:
@@ -54,6 +49,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,17 +6,21 @@ on:
       - master
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  deploy_gh_pages:
+  build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
@@ -36,9 +40,22 @@ jobs:
       - name: Build UI
         run: pnpm run build
 
-      - name: GitHub Pages Deploy
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Configure Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
-          publish_branch: gh-pages
+          path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

- Replace `peaceiris/actions-gh-pages` (which pushed to a `gh-pages` branch using a custom `PERSONAL_TOKEN` secret) with the official `actions/configure-pages` + `actions/upload-pages-artifact` + `actions/deploy-pages` flow.
- Use the default `GITHUB_TOKEN` — no more custom PAT secret required.
- Tighten workflow permissions to the minimum needed: `contents: read`, `pages: write`, `id-token: write`.
- Keep `persist-credentials: false` on the checkout step (defense-in-depth — nothing in the build job needs git auth).
- Add `concurrency: { group: pages, cancel-in-progress: false }` so simultaneous pushes serialize instead of clobbering each other mid-publish.
- Split into a `build` job (install, format check, build, upload artifact) and a `deploy` job (gated by the `github-pages` environment so the deployed URL shows up in the workflow summary).

## One-time settings change required

After this is merged, in **Settings → Pages**, switch the source from **"Deploy from a branch"** to **"GitHub Actions"**. Once a deploy run succeeds, the old `PERSONAL_TOKEN` secret and the `gh-pages` branch can be deleted.

## Test plan

- [ ] Merge to `master`
- [ ] Flip Pages source to "GitHub Actions" in repo settings
- [ ] Confirm the workflow runs both `build` and `deploy` jobs
- [ ] Confirm the deployment URL appears in the workflow summary
- [ ] Confirm `https://www.baca-quran.id/stories/` still loads
- [ ] Delete `PERSONAL_TOKEN` secret and `gh-pages` branch


---
_Generated by [Claude Code](https://claude.ai/code/session_01FSjc8JKFMXVwDedHapUD8W)_