### PR TITLE
Polish stories: hypercolor gradients, verse links, auto-fit text, tighter layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,19 +69,38 @@ pnpm-workspace.yaml       # holds allowBuilds / onlyBuiltDependencies
 | `title` | `Tentang Sabar` | Shown on the card and used in the story `<title>`. |
 | `description` | `Kumpulan quote tentang sabar ...` | Card subtitle + meta description. |
 | `publishedDate` | `2020-07-02` | ISO `YYYY-MM-DD`. Drives sort order (newest first) and the Indonesian date shown on the card. |
-| `gradient` | `linear-gradient(135deg, #4facfe 0%, #00f2fe 100%)` | The card background, ideally matching the story page's own gradient. |
+| `gradient` | `linear-gradient(135deg, #ec4899 0%, #ef4444 50%, #fbbf24 100%)` | The card background; match the story page's own gradient. **Always pick gradients from [hypercolor.dev](https://hypercolor.dev/)** (see below). |
 
 The landing page renders cards newest-first; pick `publishedDate` accordingly
 (roughly one-week gaps keep the timeline tidy).
 
+### Gradients — always source from hypercolor.dev
+
+Every `gradient` (in `content.json` and the matching `amp-story-page`
+background) must come from **[hypercolor.dev](https://hypercolor.dev/)** so the
+catalog stays visually consistent. Pick a preset there, copy its Tailwind
+`from / via / to` color stops, and express them as a CSS gradient, e.g.
+`from-pink-500 via-red-500 to-amber-400` →
+`linear-gradient(135deg, #ec4899 0%, #ef4444 50%, #fbbf24 100%)`. Keep the
+`135deg` angle for consistency, and remember the verse text sits on a dark
+scrim, so any vibrant hypercolor preset keeps white text readable.
+
 ## Adding a new story
 
 1. **Add metadata** — append an entry to `stories[]` in `content.json` (slug,
-   title, description, `publishedDate`, `gradient`).
+   title, description, `publishedDate`, `gradient` from hypercolor.dev).
 2. **Create the page** — add `src/<slug>/index.html` following the structure of
    an existing self-contained story (e.g. `src/tentang-syukur/index.html`):
-   a gradient `amp-story-page` background plus text panels for each ayat. Reuse
-   the same `gradient` colors as in `content.json` so the card and story match.
+   - The `amp-story-page` background uses the same hypercolor `gradient` as the
+     card in `content.json`.
+   - Each ayat lives on its own page: a dark scrim `.panel` containing a kicker,
+     the verse wrapped in `<amp-fit-text layout="flex-item" min-font-size="13"
+     max-font-size="30">` so long verses auto-scale and never overflow or get
+     clipped, and a `.ref` link to the verse on Baca-Quran.id
+     (`https://www.baca-quran.id/surah/<surahNumber>/<ayatNumber>/`).
+   - Load `amp-fit-text` via
+     `<script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>`.
+
    (Older stories such as `src/tentang-sabar/index.html` instead pull full-bleed
    images from `https://www.baca-quran.id/stories-content/<slug>/`; either style
    is valid.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,9 +94,9 @@ scrim, so any vibrant hypercolor preset keeps white text readable.
    - The `amp-story-page` background uses the same hypercolor `gradient` as the
      card in `content.json`.
    - Each ayat lives on its own page: a dark scrim `.panel` containing a kicker,
-     the verse wrapped in `<amp-fit-text layout="flex-item" min-font-size="13"
-     max-font-size="30">` so long verses auto-scale and never overflow or get
-     clipped, and a `.ref` link to the verse on Baca-Quran.id
+     the verse wrapped in `<amp-fit-text layout="flex-item" ...>` so it
+     auto-scales to fit and never overflows or gets clipped, and a `.ref` link
+     to the verse on Baca-Quran.id
      (`https://www.baca-quran.id/surah/<surahNumber>/<ayatNumber>/`).
    - Load `amp-fit-text` via
      `<script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>`.
@@ -104,6 +104,24 @@ scrim, so any vibrant hypercolor preset keeps white text readable.
    (Older stories such as `src/tentang-sabar/index.html` instead pull full-bleed
    images from `https://www.baca-quran.id/stories-content/<slug>/`; either style
    is valid.)
+
+### Font sizing per verse — tune `max-font-size` to verse length
+
+`amp-fit-text` always shrinks text down (to `min-font-size`) to make it fit, so
+nothing is ever clipped. But the **`max-font-size` cap is per verse** and should
+track how long the ayat is — otherwise a short verse renders awkwardly small
+while a long one starts oversized before shrinking. Keep `min-font-size="14"`
+and pick the cap by character length:
+
+| Verse length (chars) | `max-font-size` | Example |
+| --- | --- | --- |
+| ≤ 90 (very short) | `46` | Ar-Rahman 55:1 (<https://www.baca-quran.id/surah/55/1/>), Al-Fatihah 1:1 (<https://www.baca-quran.id/surah/1/1/>) |
+| ≤ 180 (medium) | `36` | most ayat |
+| ≤ 280 (long) | `28` | multi-clause ayat |
+| > 280 (very long) | `24` | e.g. Al-Isra 17:23 |
+
+So a one-line verse can fill the panel at ~46px while a long verse settles
+smaller — each page is sized to its own content, not a single fixed value.
 3. **Sync the landing page** — run `pnpm run generate:index` and commit
    `src/index.html`. This only rewrites the cards between the
    `<!-- stories:start -->` / `<!-- stories:end -->` markers inside

--- a/content.json
+++ b/content.json
@@ -10,70 +10,70 @@
       "title": "Tentang Syukur",
       "description": "Kumpulan quote tentang syukur yang diambil dari ayat-ayat Al-Quran",
       "publishedDate": "2026-04-15",
-      "gradient": "linear-gradient(135deg, #fa709a 0%, #fee140 100%)"
+      "gradient": "linear-gradient(135deg, #ec4899 0%, #ef4444 50%, #fbbf24 100%)"
     },
     {
       "slug": "tentang-tawakal",
       "title": "Tentang Tawakal",
       "description": "Kumpulan quote tentang tawakal yang diambil dari ayat-ayat Al-Quran",
       "publishedDate": "2026-04-22",
-      "gradient": "linear-gradient(135deg, #0ba360 0%, #3cba92 100%)"
+      "gradient": "linear-gradient(135deg, #10b981 0%, #14b8a6 50%, #06b6d4 100%)"
     },
     {
       "slug": "tentang-ikhlas",
       "title": "Tentang Ikhlas",
       "description": "Kumpulan quote tentang ikhlas yang diambil dari ayat-ayat Al-Quran",
       "publishedDate": "2026-04-29",
-      "gradient": "linear-gradient(135deg, #6a11cb 0%, #2575fc 100%)"
+      "gradient": "linear-gradient(135deg, #a855f7 0%, #8b5cf6 50%, #4f46e5 100%)"
     },
     {
       "slug": "tentang-taubat",
       "title": "Tentang Taubat",
       "description": "Kumpulan quote tentang taubat yang diambil dari ayat-ayat Al-Quran",
       "publishedDate": "2026-05-06",
-      "gradient": "linear-gradient(135deg, #30cfd0 0%, #330867 100%)"
+      "gradient": "linear-gradient(135deg, #1d4ed8 0%, #4338ca 50%, #6b21a8 100%)"
     },
     {
       "slug": "tentang-jujur",
       "title": "Tentang Jujur",
       "description": "Kumpulan quote tentang jujur yang diambil dari ayat-ayat Al-Quran",
       "publishedDate": "2026-05-13",
-      "gradient": "linear-gradient(135deg, #11998e 0%, #38ef7d 100%)"
+      "gradient": "linear-gradient(135deg, #84cc16 0%, #22c55e 50%, #059669 100%)"
     },
     {
       "slug": "tentang-berbakti-kepada-orang-tua",
       "title": "Tentang Berbakti kepada Orang Tua",
       "description": "Kumpulan quote tentang berbakti kepada orang tua yang diambil dari ayat-ayat Al-Quran",
       "publishedDate": "2026-05-20",
-      "gradient": "linear-gradient(135deg, #c94b4b 0%, #4b134f 100%)"
+      "gradient": "linear-gradient(135deg, #fb7185 0%, #d946ef 50%, #6366f1 100%)"
     },
     {
       "slug": "tentang-silaturahmi",
       "title": "Tentang Silaturahmi",
       "description": "Kumpulan quote tentang silaturahmi yang diambil dari ayat-ayat Al-Quran",
       "publishedDate": "2026-05-27",
-      "gradient": "linear-gradient(135deg, #2193b0 0%, #6dd5ed 100%)"
+      "gradient": "linear-gradient(135deg, #22d3ee 0%, #0ea5e9 50%, #2563eb 100%)"
     },
     {
       "slug": "tentang-menuntut-ilmu",
       "title": "Tentang Menuntut Ilmu",
       "description": "Kumpulan quote tentang menuntut ilmu yang diambil dari ayat-ayat Al-Quran",
       "publishedDate": "2020-07-12",
-      "gradient": "linear-gradient(135deg, #667eea 0%, #764ba2 100%)"
+      "gradient": "linear-gradient(135deg, #6366f1 0%, #a855f7 50%, #ec4899 100%)"
     },
     {
       "slug": "tentang-sedekah",
       "title": "Tentang Sedekah",
       "description": "Kumpulan quote tentang sedekah yang diambil dari ayat-ayat Al-Quran",
       "publishedDate": "2020-07-06",
-      "gradient": "linear-gradient(135deg, #f7971e 0%, #ffd200 100%)"
+      "gradient": "linear-gradient(135deg, #fbbf24 0%, #f97316 50%, #ef4444 100%)"
     },
     {
       "slug": "tentang-sabar",
       "title": "Tentang Sabar",
       "description": "Kumpulan quote tentang sabar yang diambil dari ayat-ayat Al-Quran",
       "publishedDate": "2020-07-02",
-      "gradient": "linear-gradient(135deg, #4facfe 0%, #00f2fe 100%)"
+      "gradient": "linear-gradient(135deg, #38bdf8 0%, #3b82f6 50%, #4f46e5 100%)"
     }
   ]
 }

--- a/src/index.html
+++ b/src/index.html
@@ -180,70 +180,70 @@
 		<article>
 			<ul class="cards">
 				<!-- stories:start — DO NOT EDIT cards below by hand; they are generated. Edit content.json, then run `pnpm run generate:index`. -->
-				<li class="card" style="background-image: linear-gradient(135deg, #2193b0 0%, #6dd5ed 100%);">
+				<li class="card" style="background-image: linear-gradient(135deg, #22d3ee 0%, #0ea5e9 50%, #2563eb 100%);">
 					<a href="/stories/tentang-silaturahmi/">
 						<h3>Tentang Silaturahmi</h3>
 					</a>
 					<small>27 Mei 2026</small>
 					<p>Kumpulan quote tentang silaturahmi yang diambil dari ayat-ayat Al-Quran</p>
 				</li>
-				<li class="card" style="background-image: linear-gradient(135deg, #c94b4b 0%, #4b134f 100%);">
+				<li class="card" style="background-image: linear-gradient(135deg, #fb7185 0%, #d946ef 50%, #6366f1 100%);">
 					<a href="/stories/tentang-berbakti-kepada-orang-tua/">
 						<h3>Tentang Berbakti kepada Orang Tua</h3>
 					</a>
 					<small>20 Mei 2026</small>
 					<p>Kumpulan quote tentang berbakti kepada orang tua yang diambil dari ayat-ayat Al-Quran</p>
 				</li>
-				<li class="card" style="background-image: linear-gradient(135deg, #11998e 0%, #38ef7d 100%);">
+				<li class="card" style="background-image: linear-gradient(135deg, #84cc16 0%, #22c55e 50%, #059669 100%);">
 					<a href="/stories/tentang-jujur/">
 						<h3>Tentang Jujur</h3>
 					</a>
 					<small>13 Mei 2026</small>
 					<p>Kumpulan quote tentang jujur yang diambil dari ayat-ayat Al-Quran</p>
 				</li>
-				<li class="card" style="background-image: linear-gradient(135deg, #30cfd0 0%, #330867 100%);">
+				<li class="card" style="background-image: linear-gradient(135deg, #1d4ed8 0%, #4338ca 50%, #6b21a8 100%);">
 					<a href="/stories/tentang-taubat/">
 						<h3>Tentang Taubat</h3>
 					</a>
 					<small>06 Mei 2026</small>
 					<p>Kumpulan quote tentang taubat yang diambil dari ayat-ayat Al-Quran</p>
 				</li>
-				<li class="card" style="background-image: linear-gradient(135deg, #6a11cb 0%, #2575fc 100%);">
+				<li class="card" style="background-image: linear-gradient(135deg, #a855f7 0%, #8b5cf6 50%, #4f46e5 100%);">
 					<a href="/stories/tentang-ikhlas/">
 						<h3>Tentang Ikhlas</h3>
 					</a>
 					<small>29 April 2026</small>
 					<p>Kumpulan quote tentang ikhlas yang diambil dari ayat-ayat Al-Quran</p>
 				</li>
-				<li class="card" style="background-image: linear-gradient(135deg, #0ba360 0%, #3cba92 100%);">
+				<li class="card" style="background-image: linear-gradient(135deg, #10b981 0%, #14b8a6 50%, #06b6d4 100%);">
 					<a href="/stories/tentang-tawakal/">
 						<h3>Tentang Tawakal</h3>
 					</a>
 					<small>22 April 2026</small>
 					<p>Kumpulan quote tentang tawakal yang diambil dari ayat-ayat Al-Quran</p>
 				</li>
-				<li class="card" style="background-image: linear-gradient(135deg, #fa709a 0%, #fee140 100%);">
+				<li class="card" style="background-image: linear-gradient(135deg, #ec4899 0%, #ef4444 50%, #fbbf24 100%);">
 					<a href="/stories/tentang-syukur/">
 						<h3>Tentang Syukur</h3>
 					</a>
 					<small>15 April 2026</small>
 					<p>Kumpulan quote tentang syukur yang diambil dari ayat-ayat Al-Quran</p>
 				</li>
-				<li class="card" style="background-image: linear-gradient(135deg, #667eea 0%, #764ba2 100%);">
+				<li class="card" style="background-image: linear-gradient(135deg, #6366f1 0%, #a855f7 50%, #ec4899 100%);">
 					<a href="/stories/tentang-menuntut-ilmu/">
 						<h3>Tentang Menuntut Ilmu</h3>
 					</a>
 					<small>12 Juli 2020</small>
 					<p>Kumpulan quote tentang menuntut ilmu yang diambil dari ayat-ayat Al-Quran</p>
 				</li>
-				<li class="card" style="background-image: linear-gradient(135deg, #f7971e 0%, #ffd200 100%);">
+				<li class="card" style="background-image: linear-gradient(135deg, #fbbf24 0%, #f97316 50%, #ef4444 100%);">
 					<a href="/stories/tentang-sedekah/">
 						<h3>Tentang Sedekah</h3>
 					</a>
 					<small>06 Juli 2020</small>
 					<p>Kumpulan quote tentang sedekah yang diambil dari ayat-ayat Al-Quran</p>
 				</li>
-				<li class="card" style="background-image: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);">
+				<li class="card" style="background-image: linear-gradient(135deg, #38bdf8 0%, #3b82f6 50%, #4f46e5 100%);">
 					<a href="/stories/tentang-sabar/">
 						<h3>Tentang Sabar</h3>
 					</a>

--- a/src/tentang-berbakti-kepada-orang-tua/index.html
+++ b/src/tentang-berbakti-kepada-orang-tua/index.html
@@ -96,73 +96,86 @@
 		}
 
 		amp-story-page {
-			background-color: #c94b4b;
-			background-image: linear-gradient(135deg, #c94b4b 0%, #4b134f 100%);
+			background-color: #fb7185;
+			background-image: linear-gradient(135deg, #fb7185 0%, #d946ef 50%, #6366f1 100%);
 		}
 
-		amp-story-grid-layer.layer {
-			align-content: center;
-			justify-items: center;
-			padding: 2.5rem 2rem;
+		.page {
+			width: 100%;
+			height: 100%;
+			box-sizing: border-box;
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+			padding: 0.9rem 0.75rem;
 		}
 
 		.panel {
-			background: rgba(0, 0, 0, 0.32);
-			border-radius: 22px;
-			padding: 2rem 1.6rem;
-			max-width: 30rem;
+			display: flex;
+			flex-direction: column;
+			max-height: 100%;
+			box-sizing: border-box;
+			background: rgba(0, 0, 0, 0.36);
+			border-radius: 18px;
+			padding: 1.1rem 1rem;
 		}
 
 		.kicker {
+			flex: 0 0 auto;
 			text-transform: uppercase;
-			letter-spacing: 0.18em;
-			font-size: 0.78rem;
+			letter-spacing: 0.16em;
+			font-size: 0.72rem;
 			opacity: 0.9;
-			margin: 0 0 1rem 0;
+			margin: 0 0 0.7rem 0;
 			text-align: center;
 		}
 
 		.quote {
-			font-size: 1.3rem;
-			line-height: 1.7;
+			flex: 1 1 auto;
+			min-height: 0;
 			text-align: center;
-			margin: 0;
-			font-weight: 400;
+			line-height: 1.5;
 		}
 
 		.ref {
-			margin: 1.4rem 0 0 0;
+			flex: 0 0 auto;
+			display: block;
+			margin: 0.9rem 0 0 0;
 			text-align: center;
-			font-size: 0.95rem;
+			font-size: 0.9rem;
 			font-weight: 700;
-			letter-spacing: 0.04em;
-			opacity: 0.95;
+			letter-spacing: 0.02em;
+			color: #fff;
+			text-decoration: underline;
+			text-underline-offset: 3px;
+		}
+
+		.cover {
+			text-align: center;
 		}
 
 		.cover-title {
-			font-size: 2.4rem;
-			line-height: 1.25;
+			font-size: 2.3rem;
+			line-height: 1.2;
 			font-weight: 700;
-			text-align: center;
 			margin: 0;
 		}
 
 		.cover-sub {
-			margin-top: 1.2rem;
-			font-size: 1.05rem;
-			text-align: center;
+			margin: 1rem 0 0 0;
+			font-size: 1rem;
 			opacity: 0.92;
-			line-height: 1.6;
+			line-height: 1.55;
 		}
 
 		.brand {
 			position: absolute;
-			bottom: 1.4rem;
+			bottom: 1.2rem;
 			left: 0;
 			right: 0;
 			text-align: center;
-			font-size: 0.78rem;
-			letter-spacing: 0.15em;
+			font-size: 0.72rem;
+			letter-spacing: 0.14em;
 			text-transform: uppercase;
 			opacity: 0.85;
 		}
@@ -170,6 +183,7 @@
 
 	<script async src="https://cdn.ampproject.org/v0.js"></script>
 	<script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+	<script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>
 	<script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
 
 </head>
@@ -180,62 +194,74 @@
 		poster-portrait-src="https://www.baca-quran.id/meta-image.png">
 
 		<amp-story-page id="cover">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fade-in">
-					<p class="kicker">Web Stories</p>
-					<h1 class="cover-title">Berbakti kepada Orang Tua</h1>
-					<p class="cover-sub">Kumpulan ayat Al-Quran tentang berbuat baik kepada ibu dan bapak</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel cover" animate-in="fade-in">
+						<p class="kicker">Web Stories</p>
+						<h1 class="cover-title">Berbakti kepada Orang Tua</h1>
+						<p class="cover-sub">Kumpulan ayat Al-Quran tentang berbuat baik kepada ibu dan bapak</p>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 			<p class="brand">Baca-Quran.id</p>
 		</amp-story-page>
 
 		<amp-story-page id="al-isra-23">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-top">
-					<p class="kicker">Birrul Walidain</p>
-					<p class="quote">"Dan Tuhanmu telah memerintahkan agar kamu jangan menyembah selain Dia dan hendaklah berbuat baik kepada ibu bapak. Jika salah seorang di antara keduanya atau kedua-duanya sampai berusia lanjut dalam pemeliharaanmu, maka janganlah sekali-kali engkau mengatakan kepada keduanya perkataan 'ah' dan janganlah engkau membentak keduanya, dan ucapkanlah kepada keduanya perkataan yang baik."</p>
-					<p class="ref">QS. Al-Isra: 23</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-top">
+						<p class="kicker">Birrul Walidain</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan Tuhanmu telah memerintahkan agar kamu jangan menyembah selain Dia dan hendaklah berbuat baik kepada ibu bapak. Jika salah seorang di antara keduanya atau kedua-duanya sampai berusia lanjut dalam pemeliharaanmu, maka janganlah sekali-kali engkau mengatakan kepada keduanya perkataan 'ah' dan janganlah engkau membentak keduanya, dan ucapkanlah kepada keduanya perkataan yang baik."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/17/23/" target="_blank" rel="noopener">Baca QS. Al-Isra: 23 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="al-isra-24">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-bottom">
-					<p class="kicker">Birrul Walidain</p>
-					<p class="quote">"Dan rendahkanlah dirimu terhadap keduanya dengan penuh kasih sayang dan ucapkanlah, 'Wahai Tuhanku! Sayangilah keduanya sebagaimana mereka berdua telah mendidik aku pada waktu kecil.'"</p>
-					<p class="ref">QS. Al-Isra: 24</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-bottom">
+						<p class="kicker">Birrul Walidain</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan rendahkanlah dirimu terhadap keduanya dengan penuh kasih sayang dan ucapkanlah, 'Wahai Tuhanku! Sayangilah keduanya sebagaimana mereka berdua telah mendidik aku pada waktu kecil.'"</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/17/24/" target="_blank" rel="noopener">Baca QS. Al-Isra: 24 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="luqman-14">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-top">
-					<p class="kicker">Birrul Walidain</p>
-					<p class="quote">"Dan Kami perintahkan kepada manusia (agar berbuat baik) kepada kedua orang tuanya. Ibunya telah mengandungnya dalam keadaan lemah yang bertambah-tambah, dan menyapihnya dalam usia dua tahun. Bersyukurlah kepada-Ku dan kepada kedua orang tuamu. Hanya kepada Aku kembalimu."</p>
-					<p class="ref">QS. Luqman: 14</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-top">
+						<p class="kicker">Birrul Walidain</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan Kami perintahkan kepada manusia (agar berbuat baik) kepada kedua orang tuanya. Ibunya telah mengandungnya dalam keadaan lemah yang bertambah-tambah, dan menyapihnya dalam usia dua tahun. Bersyukurlah kepada-Ku dan kepada kedua orang tuamu. Hanya kepada Aku kembalimu."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/31/14/" target="_blank" rel="noopener">Baca QS. Luqman: 14 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="al-ankabut-8">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-bottom">
-					<p class="kicker">Birrul Walidain</p>
-					<p class="quote">"Dan Kami wajibkan kepada manusia (berbuat) kebaikan kepada kedua orang tuanya."</p>
-					<p class="ref">QS. Al-Ankabut: 8</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-bottom">
+						<p class="kicker">Birrul Walidain</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan Kami wajibkan kepada manusia (berbuat) kebaikan kepada kedua orang tuanya."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/29/8/" target="_blank" rel="noopener">Baca QS. Al-Ankabut: 8 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="an-nisa-36">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-top">
-					<p class="kicker">Birrul Walidain</p>
-					<p class="quote">"Dan sembahlah Allah dan janganlah kamu mempersekutukan-Nya dengan sesuatu apa pun. Dan berbuat baiklah kepada kedua orang tua, karib kerabat, anak-anak yatim, dan orang-orang miskin."</p>
-					<p class="ref">QS. An-Nisa: 36</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-top">
+						<p class="kicker">Birrul Walidain</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan sembahlah Allah dan janganlah kamu mempersekutukan-Nya dengan sesuatu apa pun. Dan berbuat baiklah kepada kedua orang tua, karib kerabat, anak-anak yatim, dan orang-orang miskin."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/4/36/" target="_blank" rel="noopener">Baca QS. An-Nisa: 36 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>

--- a/src/tentang-berbakti-kepada-orang-tua/index.html
+++ b/src/tentang-berbakti-kepada-orang-tua/index.html
@@ -211,7 +211,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
 						<p class="kicker">Birrul Walidain</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan Tuhanmu telah memerintahkan agar kamu jangan menyembah selain Dia dan hendaklah berbuat baik kepada ibu bapak. Jika salah seorang di antara keduanya atau kedua-duanya sampai berusia lanjut dalam pemeliharaanmu, maka janganlah sekali-kali engkau mengatakan kepada keduanya perkataan 'ah' dan janganlah engkau membentak keduanya, dan ucapkanlah kepada keduanya perkataan yang baik."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="24" class="quote">"Dan Tuhanmu telah memerintahkan agar kamu jangan menyembah selain Dia dan hendaklah berbuat baik kepada ibu bapak. Jika salah seorang di antara keduanya atau kedua-duanya sampai berusia lanjut dalam pemeliharaanmu, maka janganlah sekali-kali engkau mengatakan kepada keduanya perkataan 'ah' dan janganlah engkau membentak keduanya, dan ucapkanlah kepada keduanya perkataan yang baik."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/17/23/" target="_blank" rel="noopener">Baca QS. Al-Isra: 23 ↗</a>
 					</div>
 				</div>
@@ -223,7 +223,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
 						<p class="kicker">Birrul Walidain</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan rendahkanlah dirimu terhadap keduanya dengan penuh kasih sayang dan ucapkanlah, 'Wahai Tuhanku! Sayangilah keduanya sebagaimana mereka berdua telah mendidik aku pada waktu kecil.'"</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="28" class="quote">"Dan rendahkanlah dirimu terhadap keduanya dengan penuh kasih sayang dan ucapkanlah, 'Wahai Tuhanku! Sayangilah keduanya sebagaimana mereka berdua telah mendidik aku pada waktu kecil.'"</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/17/24/" target="_blank" rel="noopener">Baca QS. Al-Isra: 24 ↗</a>
 					</div>
 				</div>
@@ -235,7 +235,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
 						<p class="kicker">Birrul Walidain</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan Kami perintahkan kepada manusia (agar berbuat baik) kepada kedua orang tuanya. Ibunya telah mengandungnya dalam keadaan lemah yang bertambah-tambah, dan menyapihnya dalam usia dua tahun. Bersyukurlah kepada-Ku dan kepada kedua orang tuamu. Hanya kepada Aku kembalimu."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="28" class="quote">"Dan Kami perintahkan kepada manusia (agar berbuat baik) kepada kedua orang tuanya. Ibunya telah mengandungnya dalam keadaan lemah yang bertambah-tambah, dan menyapihnya dalam usia dua tahun. Bersyukurlah kepada-Ku dan kepada kedua orang tuamu. Hanya kepada Aku kembalimu."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/31/14/" target="_blank" rel="noopener">Baca QS. Luqman: 14 ↗</a>
 					</div>
 				</div>
@@ -247,7 +247,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
 						<p class="kicker">Birrul Walidain</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan Kami wajibkan kepada manusia (berbuat) kebaikan kepada kedua orang tuanya."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="46" class="quote">"Dan Kami wajibkan kepada manusia (berbuat) kebaikan kepada kedua orang tuanya."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/29/8/" target="_blank" rel="noopener">Baca QS. Al-Ankabut: 8 ↗</a>
 					</div>
 				</div>
@@ -259,7 +259,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
 						<p class="kicker">Birrul Walidain</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan sembahlah Allah dan janganlah kamu mempersekutukan-Nya dengan sesuatu apa pun. Dan berbuat baiklah kepada kedua orang tua, karib kerabat, anak-anak yatim, dan orang-orang miskin."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="28" class="quote">"Dan sembahlah Allah dan janganlah kamu mempersekutukan-Nya dengan sesuatu apa pun. Dan berbuat baiklah kepada kedua orang tua, karib kerabat, anak-anak yatim, dan orang-orang miskin."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/4/36/" target="_blank" rel="noopener">Baca QS. An-Nisa: 36 ↗</a>
 					</div>
 				</div>

--- a/src/tentang-ikhlas/index.html
+++ b/src/tentang-ikhlas/index.html
@@ -96,73 +96,86 @@
 		}
 
 		amp-story-page {
-			background-color: #6a11cb;
-			background-image: linear-gradient(135deg, #6a11cb 0%, #2575fc 100%);
+			background-color: #a855f7;
+			background-image: linear-gradient(135deg, #a855f7 0%, #8b5cf6 50%, #4f46e5 100%);
 		}
 
-		amp-story-grid-layer.layer {
-			align-content: center;
-			justify-items: center;
-			padding: 2.5rem 2rem;
+		.page {
+			width: 100%;
+			height: 100%;
+			box-sizing: border-box;
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+			padding: 0.9rem 0.75rem;
 		}
 
 		.panel {
-			background: rgba(0, 0, 0, 0.32);
-			border-radius: 22px;
-			padding: 2rem 1.6rem;
-			max-width: 30rem;
+			display: flex;
+			flex-direction: column;
+			max-height: 100%;
+			box-sizing: border-box;
+			background: rgba(0, 0, 0, 0.36);
+			border-radius: 18px;
+			padding: 1.1rem 1rem;
 		}
 
 		.kicker {
+			flex: 0 0 auto;
 			text-transform: uppercase;
-			letter-spacing: 0.18em;
-			font-size: 0.78rem;
+			letter-spacing: 0.16em;
+			font-size: 0.72rem;
 			opacity: 0.9;
-			margin: 0 0 1rem 0;
+			margin: 0 0 0.7rem 0;
 			text-align: center;
 		}
 
 		.quote {
-			font-size: 1.4rem;
-			line-height: 1.75;
+			flex: 1 1 auto;
+			min-height: 0;
 			text-align: center;
-			margin: 0;
-			font-weight: 400;
+			line-height: 1.5;
 		}
 
 		.ref {
-			margin: 1.4rem 0 0 0;
+			flex: 0 0 auto;
+			display: block;
+			margin: 0.9rem 0 0 0;
 			text-align: center;
-			font-size: 0.95rem;
+			font-size: 0.9rem;
 			font-weight: 700;
-			letter-spacing: 0.04em;
-			opacity: 0.95;
+			letter-spacing: 0.02em;
+			color: #fff;
+			text-decoration: underline;
+			text-underline-offset: 3px;
+		}
+
+		.cover {
+			text-align: center;
 		}
 
 		.cover-title {
-			font-size: 2.9rem;
+			font-size: 2.3rem;
 			line-height: 1.2;
 			font-weight: 700;
-			text-align: center;
 			margin: 0;
 		}
 
 		.cover-sub {
-			margin-top: 1.2rem;
-			font-size: 1.05rem;
-			text-align: center;
+			margin: 1rem 0 0 0;
+			font-size: 1rem;
 			opacity: 0.92;
-			line-height: 1.6;
+			line-height: 1.55;
 		}
 
 		.brand {
 			position: absolute;
-			bottom: 1.4rem;
+			bottom: 1.2rem;
 			left: 0;
 			right: 0;
 			text-align: center;
-			font-size: 0.78rem;
-			letter-spacing: 0.15em;
+			font-size: 0.72rem;
+			letter-spacing: 0.14em;
 			text-transform: uppercase;
 			opacity: 0.85;
 		}
@@ -170,6 +183,7 @@
 
 	<script async src="https://cdn.ampproject.org/v0.js"></script>
 	<script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+	<script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>
 	<script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
 
 </head>
@@ -180,62 +194,74 @@
 		poster-portrait-src="https://www.baca-quran.id/meta-image.png">
 
 		<amp-story-page id="cover">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fade-in">
-					<p class="kicker">Web Stories</p>
-					<h1 class="cover-title">Tentang Ikhlas</h1>
-					<p class="cover-sub">Kumpulan ayat Al-Quran tentang ketulusan beribadah karena Allah</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel cover" animate-in="fade-in">
+						<p class="kicker">Web Stories</p>
+						<h1 class="cover-title">Tentang Ikhlas</h1>
+						<p class="cover-sub">Kumpulan ayat Al-Quran tentang ketulusan beribadah karena Allah</p>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 			<p class="brand">Baca-Quran.id</p>
 		</amp-story-page>
 
 		<amp-story-page id="al-bayyinah-5">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-top">
-					<p class="kicker">Ikhlas</p>
-					<p class="quote">"Padahal mereka hanya diperintah menyembah Allah dengan ikhlas menaati-Nya semata-mata karena (menjalankan) agama, dan juga agar melaksanakan salat dan menunaikan zakat; dan yang demikian itulah agama yang lurus."</p>
-					<p class="ref">QS. Al-Bayyinah: 5</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-top">
+						<p class="kicker">Ikhlas</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Padahal mereka hanya diperintah menyembah Allah dengan ikhlas menaati-Nya semata-mata karena (menjalankan) agama, dan juga agar melaksanakan salat dan menunaikan zakat; dan yang demikian itulah agama yang lurus."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/98/5/" target="_blank" rel="noopener">Baca QS. Al-Bayyinah: 5 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="az-zumar-2">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-bottom">
-					<p class="kicker">Ikhlas</p>
-					<p class="quote">"Sesungguhnya Kami menurunkan Kitab (Al-Qur'an) kepadamu dengan (membawa) kebenaran. Maka sembahlah Allah dengan tulus ikhlas beragama kepada-Nya."</p>
-					<p class="ref">QS. Az-Zumar: 2</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-bottom">
+						<p class="kicker">Ikhlas</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Sesungguhnya Kami menurunkan Kitab (Al-Qur'an) kepadamu dengan (membawa) kebenaran. Maka sembahlah Allah dengan tulus ikhlas beragama kepada-Nya."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/39/2/" target="_blank" rel="noopener">Baca QS. Az-Zumar: 2 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="al-anam-162">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-top">
-					<p class="kicker">Ikhlas</p>
-					<p class="quote">"Katakanlah (Muhammad), 'Sesungguhnya salatku, ibadahku, hidupku dan matiku hanyalah untuk Allah, Tuhan seluruh alam.'"</p>
-					<p class="ref">QS. Al-An'am: 162</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-top">
+						<p class="kicker">Ikhlas</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Katakanlah (Muhammad), 'Sesungguhnya salatku, ibadahku, hidupku dan matiku hanyalah untuk Allah, Tuhan seluruh alam.'"</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/6/162/" target="_blank" rel="noopener">Baca QS. Al-An'am: 162 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="az-zumar-11">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-bottom">
-					<p class="kicker">Ikhlas</p>
-					<p class="quote">"Katakanlah, 'Sesungguhnya aku diperintahkan menyembah Allah dengan tulus ikhlas beragama kepada-Nya.'"</p>
-					<p class="ref">QS. Az-Zumar: 11</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-bottom">
+						<p class="kicker">Ikhlas</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Katakanlah, 'Sesungguhnya aku diperintahkan menyembah Allah dengan tulus ikhlas beragama kepada-Nya.'"</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/39/11/" target="_blank" rel="noopener">Baca QS. Az-Zumar: 11 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="al-kahf-110">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-top">
-					<p class="kicker">Ikhlas</p>
-					<p class="quote">"Maka barangsiapa mengharap pertemuan dengan Tuhannya, hendaklah dia mengerjakan kebajikan dan janganlah dia mempersekutukan dengan sesuatu pun dalam beribadah kepada Tuhannya."</p>
-					<p class="ref">QS. Al-Kahf: 110</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-top">
+						<p class="kicker">Ikhlas</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Maka barangsiapa mengharap pertemuan dengan Tuhannya, hendaklah dia mengerjakan kebajikan dan janganlah dia mempersekutukan dengan sesuatu pun dalam beribadah kepada Tuhannya."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/18/110/" target="_blank" rel="noopener">Baca QS. Al-Kahf: 110 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>

--- a/src/tentang-ikhlas/index.html
+++ b/src/tentang-ikhlas/index.html
@@ -211,7 +211,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
 						<p class="kicker">Ikhlas</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Padahal mereka hanya diperintah menyembah Allah dengan ikhlas menaati-Nya semata-mata karena (menjalankan) agama, dan juga agar melaksanakan salat dan menunaikan zakat; dan yang demikian itulah agama yang lurus."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="28" class="quote">"Padahal mereka hanya diperintah menyembah Allah dengan ikhlas menaati-Nya semata-mata karena (menjalankan) agama, dan juga agar melaksanakan salat dan menunaikan zakat; dan yang demikian itulah agama yang lurus."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/98/5/" target="_blank" rel="noopener">Baca QS. Al-Bayyinah: 5 ↗</a>
 					</div>
 				</div>
@@ -223,7 +223,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
 						<p class="kicker">Ikhlas</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Sesungguhnya Kami menurunkan Kitab (Al-Qur'an) kepadamu dengan (membawa) kebenaran. Maka sembahlah Allah dengan tulus ikhlas beragama kepada-Nya."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Sesungguhnya Kami menurunkan Kitab (Al-Qur'an) kepadamu dengan (membawa) kebenaran. Maka sembahlah Allah dengan tulus ikhlas beragama kepada-Nya."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/39/2/" target="_blank" rel="noopener">Baca QS. Az-Zumar: 2 ↗</a>
 					</div>
 				</div>
@@ -235,7 +235,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
 						<p class="kicker">Ikhlas</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Katakanlah (Muhammad), 'Sesungguhnya salatku, ibadahku, hidupku dan matiku hanyalah untuk Allah, Tuhan seluruh alam.'"</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Katakanlah (Muhammad), 'Sesungguhnya salatku, ibadahku, hidupku dan matiku hanyalah untuk Allah, Tuhan seluruh alam.'"</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/6/162/" target="_blank" rel="noopener">Baca QS. Al-An'am: 162 ↗</a>
 					</div>
 				</div>
@@ -247,7 +247,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
 						<p class="kicker">Ikhlas</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Katakanlah, 'Sesungguhnya aku diperintahkan menyembah Allah dengan tulus ikhlas beragama kepada-Nya.'"</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Katakanlah, 'Sesungguhnya aku diperintahkan menyembah Allah dengan tulus ikhlas beragama kepada-Nya.'"</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/39/11/" target="_blank" rel="noopener">Baca QS. Az-Zumar: 11 ↗</a>
 					</div>
 				</div>
@@ -259,7 +259,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
 						<p class="kicker">Ikhlas</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Maka barangsiapa mengharap pertemuan dengan Tuhannya, hendaklah dia mengerjakan kebajikan dan janganlah dia mempersekutukan dengan sesuatu pun dalam beribadah kepada Tuhannya."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Maka barangsiapa mengharap pertemuan dengan Tuhannya, hendaklah dia mengerjakan kebajikan dan janganlah dia mempersekutukan dengan sesuatu pun dalam beribadah kepada Tuhannya."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/18/110/" target="_blank" rel="noopener">Baca QS. Al-Kahf: 110 ↗</a>
 					</div>
 				</div>

--- a/src/tentang-jujur/index.html
+++ b/src/tentang-jujur/index.html
@@ -96,73 +96,86 @@
 		}
 
 		amp-story-page {
-			background-color: #11998e;
-			background-image: linear-gradient(135deg, #11998e 0%, #38ef7d 100%);
+			background-color: #84cc16;
+			background-image: linear-gradient(135deg, #84cc16 0%, #22c55e 50%, #059669 100%);
 		}
 
-		amp-story-grid-layer.layer {
-			align-content: center;
-			justify-items: center;
-			padding: 2.5rem 2rem;
+		.page {
+			width: 100%;
+			height: 100%;
+			box-sizing: border-box;
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+			padding: 0.9rem 0.75rem;
 		}
 
 		.panel {
-			background: rgba(0, 0, 0, 0.32);
-			border-radius: 22px;
-			padding: 2rem 1.6rem;
-			max-width: 30rem;
+			display: flex;
+			flex-direction: column;
+			max-height: 100%;
+			box-sizing: border-box;
+			background: rgba(0, 0, 0, 0.36);
+			border-radius: 18px;
+			padding: 1.1rem 1rem;
 		}
 
 		.kicker {
+			flex: 0 0 auto;
 			text-transform: uppercase;
-			letter-spacing: 0.18em;
-			font-size: 0.78rem;
+			letter-spacing: 0.16em;
+			font-size: 0.72rem;
 			opacity: 0.9;
-			margin: 0 0 1rem 0;
+			margin: 0 0 0.7rem 0;
 			text-align: center;
 		}
 
 		.quote {
-			font-size: 1.4rem;
-			line-height: 1.75;
+			flex: 1 1 auto;
+			min-height: 0;
 			text-align: center;
-			margin: 0;
-			font-weight: 400;
+			line-height: 1.5;
 		}
 
 		.ref {
-			margin: 1.4rem 0 0 0;
+			flex: 0 0 auto;
+			display: block;
+			margin: 0.9rem 0 0 0;
 			text-align: center;
-			font-size: 0.95rem;
+			font-size: 0.9rem;
 			font-weight: 700;
-			letter-spacing: 0.04em;
-			opacity: 0.95;
+			letter-spacing: 0.02em;
+			color: #fff;
+			text-decoration: underline;
+			text-underline-offset: 3px;
+		}
+
+		.cover {
+			text-align: center;
 		}
 
 		.cover-title {
-			font-size: 2.9rem;
+			font-size: 2.3rem;
 			line-height: 1.2;
 			font-weight: 700;
-			text-align: center;
 			margin: 0;
 		}
 
 		.cover-sub {
-			margin-top: 1.2rem;
-			font-size: 1.05rem;
-			text-align: center;
+			margin: 1rem 0 0 0;
+			font-size: 1rem;
 			opacity: 0.92;
-			line-height: 1.6;
+			line-height: 1.55;
 		}
 
 		.brand {
 			position: absolute;
-			bottom: 1.4rem;
+			bottom: 1.2rem;
 			left: 0;
 			right: 0;
 			text-align: center;
-			font-size: 0.78rem;
-			letter-spacing: 0.15em;
+			font-size: 0.72rem;
+			letter-spacing: 0.14em;
 			text-transform: uppercase;
 			opacity: 0.85;
 		}
@@ -170,6 +183,7 @@
 
 	<script async src="https://cdn.ampproject.org/v0.js"></script>
 	<script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+	<script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>
 	<script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
 
 </head>
@@ -180,62 +194,74 @@
 		poster-portrait-src="https://www.baca-quran.id/meta-image.png">
 
 		<amp-story-page id="cover">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fade-in">
-					<p class="kicker">Web Stories</p>
-					<h1 class="cover-title">Tentang Jujur</h1>
-					<p class="cover-sub">Kumpulan ayat Al-Quran tentang kebenaran dan kejujuran</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel cover" animate-in="fade-in">
+						<p class="kicker">Web Stories</p>
+						<h1 class="cover-title">Tentang Jujur</h1>
+						<p class="cover-sub">Kumpulan ayat Al-Quran tentang kebenaran dan kejujuran</p>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 			<p class="brand">Baca-Quran.id</p>
 		</amp-story-page>
 
 		<amp-story-page id="at-taubah-119">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-top">
-					<p class="kicker">Jujur</p>
-					<p class="quote">"Wahai orang-orang yang beriman! Bertakwalah kepada Allah, dan bersamalah kamu dengan orang-orang yang benar."</p>
-					<p class="ref">QS. At-Taubah: 119</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-top">
+						<p class="kicker">Jujur</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Wahai orang-orang yang beriman! Bertakwalah kepada Allah, dan bersamalah kamu dengan orang-orang yang benar."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/9/119/" target="_blank" rel="noopener">Baca QS. At-Taubah: 119 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="al-ahzab-70">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-bottom">
-					<p class="kicker">Jujur</p>
-					<p class="quote">"Wahai orang-orang yang beriman! Bertakwalah kamu kepada Allah dan ucapkanlah perkataan yang benar,"</p>
-					<p class="ref">QS. Al-Ahzab: 70</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-bottom">
+						<p class="kicker">Jujur</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Wahai orang-orang yang beriman! Bertakwalah kamu kepada Allah dan ucapkanlah perkataan yang benar,"</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/33/70/" target="_blank" rel="noopener">Baca QS. Al-Ahzab: 70 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="al-ahzab-71">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-top">
-					<p class="kicker">Jujur</p>
-					<p class="quote">"niscaya Allah akan memperbaiki amal-amalmu dan mengampuni dosa-dosamu. Dan barangsiapa menaati Allah dan Rasul-Nya, maka sungguh, dia menang dengan kemenangan yang agung."</p>
-					<p class="ref">QS. Al-Ahzab: 71</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-top">
+						<p class="kicker">Jujur</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"niscaya Allah akan memperbaiki amal-amalmu dan mengampuni dosa-dosamu. Dan barangsiapa menaati Allah dan Rasul-Nya, maka sungguh, dia menang dengan kemenangan yang agung."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/33/71/" target="_blank" rel="noopener">Baca QS. Al-Ahzab: 71 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="az-zumar-33">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-bottom">
-					<p class="kicker">Jujur</p>
-					<p class="quote">"Dan orang yang membawa kebenaran (Muhammad) dan orang yang membenarkannya, mereka itulah orang yang bertakwa."</p>
-					<p class="ref">QS. Az-Zumar: 33</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-bottom">
+						<p class="kicker">Jujur</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan orang yang membawa kebenaran (Muhammad) dan orang yang membenarkannya, mereka itulah orang yang bertakwa."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/39/33/" target="_blank" rel="noopener">Baca QS. Az-Zumar: 33 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="al-maidah-119">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-top">
-					<p class="kicker">Jujur</p>
-					<p class="quote">"Inilah saat orang yang benar memperoleh manfaat dari kebenarannya. Mereka memperoleh surga yang mengalir di bawahnya sungai-sungai, mereka kekal di dalamnya selama-lamanya."</p>
-					<p class="ref">QS. Al-Ma'idah: 119</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-top">
+						<p class="kicker">Jujur</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Inilah saat orang yang benar memperoleh manfaat dari kebenarannya. Mereka memperoleh surga yang mengalir di bawahnya sungai-sungai, mereka kekal di dalamnya selama-lamanya."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/5/119/" target="_blank" rel="noopener">Baca QS. Al-Ma'idah: 119 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>

--- a/src/tentang-jujur/index.html
+++ b/src/tentang-jujur/index.html
@@ -211,7 +211,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
 						<p class="kicker">Jujur</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Wahai orang-orang yang beriman! Bertakwalah kepada Allah, dan bersamalah kamu dengan orang-orang yang benar."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Wahai orang-orang yang beriman! Bertakwalah kepada Allah, dan bersamalah kamu dengan orang-orang yang benar."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/9/119/" target="_blank" rel="noopener">Baca QS. At-Taubah: 119 ↗</a>
 					</div>
 				</div>
@@ -223,7 +223,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
 						<p class="kicker">Jujur</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Wahai orang-orang yang beriman! Bertakwalah kamu kepada Allah dan ucapkanlah perkataan yang benar,"</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Wahai orang-orang yang beriman! Bertakwalah kamu kepada Allah dan ucapkanlah perkataan yang benar,"</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/33/70/" target="_blank" rel="noopener">Baca QS. Al-Ahzab: 70 ↗</a>
 					</div>
 				</div>
@@ -235,7 +235,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
 						<p class="kicker">Jujur</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"niscaya Allah akan memperbaiki amal-amalmu dan mengampuni dosa-dosamu. Dan barangsiapa menaati Allah dan Rasul-Nya, maka sungguh, dia menang dengan kemenangan yang agung."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"niscaya Allah akan memperbaiki amal-amalmu dan mengampuni dosa-dosamu. Dan barangsiapa menaati Allah dan Rasul-Nya, maka sungguh, dia menang dengan kemenangan yang agung."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/33/71/" target="_blank" rel="noopener">Baca QS. Al-Ahzab: 71 ↗</a>
 					</div>
 				</div>
@@ -247,7 +247,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
 						<p class="kicker">Jujur</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan orang yang membawa kebenaran (Muhammad) dan orang yang membenarkannya, mereka itulah orang yang bertakwa."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan orang yang membawa kebenaran (Muhammad) dan orang yang membenarkannya, mereka itulah orang yang bertakwa."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/39/33/" target="_blank" rel="noopener">Baca QS. Az-Zumar: 33 ↗</a>
 					</div>
 				</div>
@@ -259,7 +259,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
 						<p class="kicker">Jujur</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Inilah saat orang yang benar memperoleh manfaat dari kebenarannya. Mereka memperoleh surga yang mengalir di bawahnya sungai-sungai, mereka kekal di dalamnya selama-lamanya."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Inilah saat orang yang benar memperoleh manfaat dari kebenarannya. Mereka memperoleh surga yang mengalir di bawahnya sungai-sungai, mereka kekal di dalamnya selama-lamanya."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/5/119/" target="_blank" rel="noopener">Baca QS. Al-Ma'idah: 119 ↗</a>
 					</div>
 				</div>

--- a/src/tentang-silaturahmi/index.html
+++ b/src/tentang-silaturahmi/index.html
@@ -211,7 +211,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
 						<p class="kicker">Silaturahmi</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan bertakwalah kepada Allah yang dengan nama-Nya kamu saling meminta, dan (peliharalah) hubungan kekeluargaan. Sesungguhnya Allah selalu menjaga dan mengawasimu."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan bertakwalah kepada Allah yang dengan nama-Nya kamu saling meminta, dan (peliharalah) hubungan kekeluargaan. Sesungguhnya Allah selalu menjaga dan mengawasimu."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/4/1/" target="_blank" rel="noopener">Baca QS. An-Nisa: 1 ↗</a>
 					</div>
 				</div>
@@ -223,7 +223,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
 						<p class="kicker">Silaturahmi</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan orang-orang yang menghubungkan apa yang diperintahkan Allah agar dihubungkan, dan mereka takut kepada Tuhannya dan takut kepada hisab yang buruk."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan orang-orang yang menghubungkan apa yang diperintahkan Allah agar dihubungkan, dan mereka takut kepada Tuhannya dan takut kepada hisab yang buruk."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/13/21/" target="_blank" rel="noopener">Baca QS. Ar-Ra'd: 21 ↗</a>
 					</div>
 				</div>
@@ -235,7 +235,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
 						<p class="kicker">Silaturahmi</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Sesungguhnya Allah menyuruh (kamu) berlaku adil dan berbuat kebajikan, memberi bantuan kepada kerabat, dan Dia melarang (melakukan) perbuatan keji, kemungkaran, dan permusuhan."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Sesungguhnya Allah menyuruh (kamu) berlaku adil dan berbuat kebajikan, memberi bantuan kepada kerabat, dan Dia melarang (melakukan) perbuatan keji, kemungkaran, dan permusuhan."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/16/90/" target="_blank" rel="noopener">Baca QS. An-Nahl: 90 ↗</a>
 					</div>
 				</div>
@@ -247,7 +247,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
 						<p class="kicker">Silaturahmi</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Maka apakah sekiranya kamu berkuasa, kamu akan berbuat kerusakan di bumi dan memutuskan hubungan kekeluargaan?"</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Maka apakah sekiranya kamu berkuasa, kamu akan berbuat kerusakan di bumi dan memutuskan hubungan kekeluargaan?"</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/47/22/" target="_blank" rel="noopener">Baca QS. Muhammad: 22 ↗</a>
 					</div>
 				</div>
@@ -259,7 +259,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
 						<p class="kicker">Silaturahmi</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan berikanlah haknya kepada kerabat dekat, juga kepada orang miskin dan orang yang dalam perjalanan; dan janganlah kamu menghambur-hamburkan (hartamu) secara boros."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan berikanlah haknya kepada kerabat dekat, juga kepada orang miskin dan orang yang dalam perjalanan; dan janganlah kamu menghambur-hamburkan (hartamu) secara boros."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/17/26/" target="_blank" rel="noopener">Baca QS. Al-Isra: 26 ↗</a>
 					</div>
 				</div>

--- a/src/tentang-silaturahmi/index.html
+++ b/src/tentang-silaturahmi/index.html
@@ -96,73 +96,86 @@
 		}
 
 		amp-story-page {
-			background-color: #2193b0;
-			background-image: linear-gradient(135deg, #2193b0 0%, #6dd5ed 100%);
+			background-color: #22d3ee;
+			background-image: linear-gradient(135deg, #22d3ee 0%, #0ea5e9 50%, #2563eb 100%);
 		}
 
-		amp-story-grid-layer.layer {
-			align-content: center;
-			justify-items: center;
-			padding: 2.5rem 2rem;
+		.page {
+			width: 100%;
+			height: 100%;
+			box-sizing: border-box;
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+			padding: 0.9rem 0.75rem;
 		}
 
 		.panel {
-			background: rgba(0, 0, 0, 0.32);
-			border-radius: 22px;
-			padding: 2rem 1.6rem;
-			max-width: 30rem;
+			display: flex;
+			flex-direction: column;
+			max-height: 100%;
+			box-sizing: border-box;
+			background: rgba(0, 0, 0, 0.36);
+			border-radius: 18px;
+			padding: 1.1rem 1rem;
 		}
 
 		.kicker {
+			flex: 0 0 auto;
 			text-transform: uppercase;
-			letter-spacing: 0.18em;
-			font-size: 0.78rem;
+			letter-spacing: 0.16em;
+			font-size: 0.72rem;
 			opacity: 0.9;
-			margin: 0 0 1rem 0;
+			margin: 0 0 0.7rem 0;
 			text-align: center;
 		}
 
 		.quote {
-			font-size: 1.4rem;
-			line-height: 1.75;
+			flex: 1 1 auto;
+			min-height: 0;
 			text-align: center;
-			margin: 0;
-			font-weight: 400;
+			line-height: 1.5;
 		}
 
 		.ref {
-			margin: 1.4rem 0 0 0;
+			flex: 0 0 auto;
+			display: block;
+			margin: 0.9rem 0 0 0;
 			text-align: center;
-			font-size: 0.95rem;
+			font-size: 0.9rem;
 			font-weight: 700;
-			letter-spacing: 0.04em;
-			opacity: 0.95;
+			letter-spacing: 0.02em;
+			color: #fff;
+			text-decoration: underline;
+			text-underline-offset: 3px;
+		}
+
+		.cover {
+			text-align: center;
 		}
 
 		.cover-title {
-			font-size: 2.7rem;
+			font-size: 2.3rem;
 			line-height: 1.2;
 			font-weight: 700;
-			text-align: center;
 			margin: 0;
 		}
 
 		.cover-sub {
-			margin-top: 1.2rem;
-			font-size: 1.05rem;
-			text-align: center;
+			margin: 1rem 0 0 0;
+			font-size: 1rem;
 			opacity: 0.92;
-			line-height: 1.6;
+			line-height: 1.55;
 		}
 
 		.brand {
 			position: absolute;
-			bottom: 1.4rem;
+			bottom: 1.2rem;
 			left: 0;
 			right: 0;
 			text-align: center;
-			font-size: 0.78rem;
-			letter-spacing: 0.15em;
+			font-size: 0.72rem;
+			letter-spacing: 0.14em;
 			text-transform: uppercase;
 			opacity: 0.85;
 		}
@@ -170,6 +183,7 @@
 
 	<script async src="https://cdn.ampproject.org/v0.js"></script>
 	<script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+	<script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>
 	<script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
 
 </head>
@@ -180,62 +194,74 @@
 		poster-portrait-src="https://www.baca-quran.id/meta-image.png">
 
 		<amp-story-page id="cover">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fade-in">
-					<p class="kicker">Web Stories</p>
-					<h1 class="cover-title">Tentang Silaturahmi</h1>
-					<p class="cover-sub">Kumpulan ayat Al-Quran tentang menyambung hubungan kekeluargaan</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel cover" animate-in="fade-in">
+						<p class="kicker">Web Stories</p>
+						<h1 class="cover-title">Tentang Silaturahmi</h1>
+						<p class="cover-sub">Kumpulan ayat Al-Quran tentang menyambung hubungan kekeluargaan</p>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 			<p class="brand">Baca-Quran.id</p>
 		</amp-story-page>
 
 		<amp-story-page id="an-nisa-1">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-top">
-					<p class="kicker">Silaturahmi</p>
-					<p class="quote">"Dan bertakwalah kepada Allah yang dengan nama-Nya kamu saling meminta, dan (peliharalah) hubungan kekeluargaan. Sesungguhnya Allah selalu menjaga dan mengawasimu."</p>
-					<p class="ref">QS. An-Nisa: 1</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-top">
+						<p class="kicker">Silaturahmi</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan bertakwalah kepada Allah yang dengan nama-Nya kamu saling meminta, dan (peliharalah) hubungan kekeluargaan. Sesungguhnya Allah selalu menjaga dan mengawasimu."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/4/1/" target="_blank" rel="noopener">Baca QS. An-Nisa: 1 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="ar-rad-21">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-bottom">
-					<p class="kicker">Silaturahmi</p>
-					<p class="quote">"Dan orang-orang yang menghubungkan apa yang diperintahkan Allah agar dihubungkan, dan mereka takut kepada Tuhannya dan takut kepada hisab yang buruk."</p>
-					<p class="ref">QS. Ar-Ra'd: 21</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-bottom">
+						<p class="kicker">Silaturahmi</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan orang-orang yang menghubungkan apa yang diperintahkan Allah agar dihubungkan, dan mereka takut kepada Tuhannya dan takut kepada hisab yang buruk."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/13/21/" target="_blank" rel="noopener">Baca QS. Ar-Ra'd: 21 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="an-nahl-90">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-top">
-					<p class="kicker">Silaturahmi</p>
-					<p class="quote">"Sesungguhnya Allah menyuruh (kamu) berlaku adil dan berbuat kebajikan, memberi bantuan kepada kerabat, dan Dia melarang (melakukan) perbuatan keji, kemungkaran, dan permusuhan."</p>
-					<p class="ref">QS. An-Nahl: 90</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-top">
+						<p class="kicker">Silaturahmi</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Sesungguhnya Allah menyuruh (kamu) berlaku adil dan berbuat kebajikan, memberi bantuan kepada kerabat, dan Dia melarang (melakukan) perbuatan keji, kemungkaran, dan permusuhan."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/16/90/" target="_blank" rel="noopener">Baca QS. An-Nahl: 90 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="muhammad-22">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-bottom">
-					<p class="kicker">Silaturahmi</p>
-					<p class="quote">"Maka apakah sekiranya kamu berkuasa, kamu akan berbuat kerusakan di bumi dan memutuskan hubungan kekeluargaan?"</p>
-					<p class="ref">QS. Muhammad: 22</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-bottom">
+						<p class="kicker">Silaturahmi</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Maka apakah sekiranya kamu berkuasa, kamu akan berbuat kerusakan di bumi dan memutuskan hubungan kekeluargaan?"</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/47/22/" target="_blank" rel="noopener">Baca QS. Muhammad: 22 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="al-isra-26">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-top">
-					<p class="kicker">Silaturahmi</p>
-					<p class="quote">"Dan berikanlah haknya kepada kerabat dekat, juga kepada orang miskin dan orang yang dalam perjalanan; dan janganlah kamu menghambur-hamburkan (hartamu) secara boros."</p>
-					<p class="ref">QS. Al-Isra: 26</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-top">
+						<p class="kicker">Silaturahmi</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan berikanlah haknya kepada kerabat dekat, juga kepada orang miskin dan orang yang dalam perjalanan; dan janganlah kamu menghambur-hamburkan (hartamu) secara boros."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/17/26/" target="_blank" rel="noopener">Baca QS. Al-Isra: 26 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>

--- a/src/tentang-syukur/index.html
+++ b/src/tentang-syukur/index.html
@@ -211,7 +211,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
 						<p class="kicker">Syukur</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Sesungguhnya jika kamu bersyukur, niscaya Aku akan menambah (nikmat) kepadamu, tetapi jika kamu mengingkari (nikmat-Ku), maka sesungguhnya azab-Ku sangat pedih."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Sesungguhnya jika kamu bersyukur, niscaya Aku akan menambah (nikmat) kepadamu, tetapi jika kamu mengingkari (nikmat-Ku), maka sesungguhnya azab-Ku sangat pedih."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/14/7/" target="_blank" rel="noopener">Baca QS. Ibrahim: 7 ↗</a>
 					</div>
 				</div>
@@ -223,7 +223,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
 						<p class="kicker">Syukur</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Maka ingatlah kepada-Ku, Aku pun akan ingat kepadamu. Bersyukurlah kepada-Ku, dan janganlah kamu ingkar kepada-Ku."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Maka ingatlah kepada-Ku, Aku pun akan ingat kepadamu. Bersyukurlah kepada-Ku, dan janganlah kamu ingkar kepada-Ku."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/2/152/" target="_blank" rel="noopener">Baca QS. Al-Baqarah: 152 ↗</a>
 					</div>
 				</div>
@@ -235,7 +235,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
 						<p class="kicker">Syukur</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan jika kamu menghitung nikmat Allah, niscaya kamu tidak akan mampu menghitungnya. Sungguh, Allah benar-benar Maha Pengampun, Maha Penyayang."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan jika kamu menghitung nikmat Allah, niscaya kamu tidak akan mampu menghitungnya. Sungguh, Allah benar-benar Maha Pengampun, Maha Penyayang."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/16/18/" target="_blank" rel="noopener">Baca QS. An-Nahl: 18 ↗</a>
 					</div>
 				</div>
@@ -247,7 +247,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
 						<p class="kicker">Syukur</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Barangsiapa bersyukur (kepada Allah), maka sesungguhnya dia bersyukur untuk dirinya sendiri; dan barangsiapa tidak bersyukur, maka sesungguhnya Allah Mahakaya, Maha Terpuji."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Barangsiapa bersyukur (kepada Allah), maka sesungguhnya dia bersyukur untuk dirinya sendiri; dan barangsiapa tidak bersyukur, maka sesungguhnya Allah Mahakaya, Maha Terpuji."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/31/12/" target="_blank" rel="noopener">Baca QS. Luqman: 12 ↗</a>
 					</div>
 				</div>
@@ -259,7 +259,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
 						<p class="kicker">Syukur</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan Dia tidak meridai kekafiran bagi hamba-Nya. Jika kamu bersyukur, Dia meridai kesyukuranmu itu."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan Dia tidak meridai kekafiran bagi hamba-Nya. Jika kamu bersyukur, Dia meridai kesyukuranmu itu."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/39/7/" target="_blank" rel="noopener">Baca QS. Az-Zumar: 7 ↗</a>
 					</div>
 				</div>

--- a/src/tentang-syukur/index.html
+++ b/src/tentang-syukur/index.html
@@ -96,73 +96,86 @@
 		}
 
 		amp-story-page {
-			background-color: #fa709a;
-			background-image: linear-gradient(135deg, #fa709a 0%, #fee140 100%);
+			background-color: #ec4899;
+			background-image: linear-gradient(135deg, #ec4899 0%, #ef4444 50%, #fbbf24 100%);
 		}
 
-		amp-story-grid-layer.layer {
-			align-content: center;
-			justify-items: center;
-			padding: 2.5rem 2rem;
+		.page {
+			width: 100%;
+			height: 100%;
+			box-sizing: border-box;
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+			padding: 0.9rem 0.75rem;
 		}
 
 		.panel {
-			background: rgba(0, 0, 0, 0.32);
-			border-radius: 22px;
-			padding: 2rem 1.6rem;
-			max-width: 30rem;
+			display: flex;
+			flex-direction: column;
+			max-height: 100%;
+			box-sizing: border-box;
+			background: rgba(0, 0, 0, 0.36);
+			border-radius: 18px;
+			padding: 1.1rem 1rem;
 		}
 
 		.kicker {
+			flex: 0 0 auto;
 			text-transform: uppercase;
-			letter-spacing: 0.18em;
-			font-size: 0.78rem;
+			letter-spacing: 0.16em;
+			font-size: 0.72rem;
 			opacity: 0.9;
-			margin: 0 0 1rem 0;
+			margin: 0 0 0.7rem 0;
 			text-align: center;
 		}
 
 		.quote {
-			font-size: 1.4rem;
-			line-height: 1.75;
+			flex: 1 1 auto;
+			min-height: 0;
 			text-align: center;
-			margin: 0;
-			font-weight: 400;
+			line-height: 1.5;
 		}
 
 		.ref {
-			margin: 1.4rem 0 0 0;
+			flex: 0 0 auto;
+			display: block;
+			margin: 0.9rem 0 0 0;
 			text-align: center;
-			font-size: 0.95rem;
+			font-size: 0.9rem;
 			font-weight: 700;
-			letter-spacing: 0.04em;
-			opacity: 0.95;
+			letter-spacing: 0.02em;
+			color: #fff;
+			text-decoration: underline;
+			text-underline-offset: 3px;
+		}
+
+		.cover {
+			text-align: center;
 		}
 
 		.cover-title {
-			font-size: 2.9rem;
+			font-size: 2.3rem;
 			line-height: 1.2;
 			font-weight: 700;
-			text-align: center;
 			margin: 0;
 		}
 
 		.cover-sub {
-			margin-top: 1.2rem;
-			font-size: 1.05rem;
-			text-align: center;
+			margin: 1rem 0 0 0;
+			font-size: 1rem;
 			opacity: 0.92;
-			line-height: 1.6;
+			line-height: 1.55;
 		}
 
 		.brand {
 			position: absolute;
-			bottom: 1.4rem;
+			bottom: 1.2rem;
 			left: 0;
 			right: 0;
 			text-align: center;
-			font-size: 0.78rem;
-			letter-spacing: 0.15em;
+			font-size: 0.72rem;
+			letter-spacing: 0.14em;
 			text-transform: uppercase;
 			opacity: 0.85;
 		}
@@ -170,6 +183,7 @@
 
 	<script async src="https://cdn.ampproject.org/v0.js"></script>
 	<script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+	<script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>
 	<script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
 
 </head>
@@ -180,62 +194,74 @@
 		poster-portrait-src="https://www.baca-quran.id/meta-image.png">
 
 		<amp-story-page id="cover">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fade-in">
-					<p class="kicker">Web Stories</p>
-					<h1 class="cover-title">Tentang Syukur</h1>
-					<p class="cover-sub">Kumpulan ayat Al-Quran tentang bersyukur atas nikmat Allah</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel cover" animate-in="fade-in">
+						<p class="kicker">Web Stories</p>
+						<h1 class="cover-title">Tentang Syukur</h1>
+						<p class="cover-sub">Kumpulan ayat Al-Quran tentang bersyukur atas nikmat Allah</p>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 			<p class="brand">Baca-Quran.id</p>
 		</amp-story-page>
 
 		<amp-story-page id="ibrahim-7">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-top">
-					<p class="kicker">Syukur</p>
-					<p class="quote">"Sesungguhnya jika kamu bersyukur, niscaya Aku akan menambah (nikmat) kepadamu, tetapi jika kamu mengingkari (nikmat-Ku), maka sesungguhnya azab-Ku sangat pedih."</p>
-					<p class="ref">QS. Ibrahim: 7</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-top">
+						<p class="kicker">Syukur</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Sesungguhnya jika kamu bersyukur, niscaya Aku akan menambah (nikmat) kepadamu, tetapi jika kamu mengingkari (nikmat-Ku), maka sesungguhnya azab-Ku sangat pedih."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/14/7/" target="_blank" rel="noopener">Baca QS. Ibrahim: 7 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="al-baqarah-152">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-bottom">
-					<p class="kicker">Syukur</p>
-					<p class="quote">"Maka ingatlah kepada-Ku, Aku pun akan ingat kepadamu. Bersyukurlah kepada-Ku, dan janganlah kamu ingkar kepada-Ku."</p>
-					<p class="ref">QS. Al-Baqarah: 152</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-bottom">
+						<p class="kicker">Syukur</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Maka ingatlah kepada-Ku, Aku pun akan ingat kepadamu. Bersyukurlah kepada-Ku, dan janganlah kamu ingkar kepada-Ku."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/2/152/" target="_blank" rel="noopener">Baca QS. Al-Baqarah: 152 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="an-nahl-18">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-top">
-					<p class="kicker">Syukur</p>
-					<p class="quote">"Dan jika kamu menghitung nikmat Allah, niscaya kamu tidak akan mampu menghitungnya. Sungguh, Allah benar-benar Maha Pengampun, Maha Penyayang."</p>
-					<p class="ref">QS. An-Nahl: 18</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-top">
+						<p class="kicker">Syukur</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan jika kamu menghitung nikmat Allah, niscaya kamu tidak akan mampu menghitungnya. Sungguh, Allah benar-benar Maha Pengampun, Maha Penyayang."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/16/18/" target="_blank" rel="noopener">Baca QS. An-Nahl: 18 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="luqman-12">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-bottom">
-					<p class="kicker">Syukur</p>
-					<p class="quote">"Barangsiapa bersyukur (kepada Allah), maka sesungguhnya dia bersyukur untuk dirinya sendiri; dan barangsiapa tidak bersyukur, maka sesungguhnya Allah Mahakaya, Maha Terpuji."</p>
-					<p class="ref">QS. Luqman: 12</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-bottom">
+						<p class="kicker">Syukur</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Barangsiapa bersyukur (kepada Allah), maka sesungguhnya dia bersyukur untuk dirinya sendiri; dan barangsiapa tidak bersyukur, maka sesungguhnya Allah Mahakaya, Maha Terpuji."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/31/12/" target="_blank" rel="noopener">Baca QS. Luqman: 12 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="az-zumar-7">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-top">
-					<p class="kicker">Syukur</p>
-					<p class="quote">"Dan Dia tidak meridai kekafiran bagi hamba-Nya. Jika kamu bersyukur, Dia meridai kesyukuranmu itu."</p>
-					<p class="ref">QS. Az-Zumar: 7</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-top">
+						<p class="kicker">Syukur</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan Dia tidak meridai kekafiran bagi hamba-Nya. Jika kamu bersyukur, Dia meridai kesyukuranmu itu."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/39/7/" target="_blank" rel="noopener">Baca QS. Az-Zumar: 7 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>

--- a/src/tentang-taubat/index.html
+++ b/src/tentang-taubat/index.html
@@ -211,7 +211,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
 						<p class="kicker">Taubat</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Wahai hamba-hamba-Ku yang melampaui batas terhadap diri mereka sendiri! Janganlah kamu berputus asa dari rahmat Allah. Sesungguhnya Allah mengampuni dosa-dosa semuanya. Sungguh, Dialah Yang Maha Pengampun, Maha Penyayang."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="28" class="quote">"Wahai hamba-hamba-Ku yang melampaui batas terhadap diri mereka sendiri! Janganlah kamu berputus asa dari rahmat Allah. Sesungguhnya Allah mengampuni dosa-dosa semuanya. Sungguh, Dialah Yang Maha Pengampun, Maha Penyayang."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/39/53/" target="_blank" rel="noopener">Baca QS. Az-Zumar: 53 ↗</a>
 					</div>
 				</div>
@@ -223,7 +223,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
 						<p class="kicker">Taubat</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Wahai orang-orang yang beriman! Bertobatlah kepada Allah dengan tobat yang semurni-murninya, mudah-mudahan Tuhanmu akan menghapus kesalahan-kesalahanmu."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Wahai orang-orang yang beriman! Bertobatlah kepada Allah dengan tobat yang semurni-murninya, mudah-mudahan Tuhanmu akan menghapus kesalahan-kesalahanmu."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/66/8/" target="_blank" rel="noopener">Baca QS. At-Tahrim: 8 ↗</a>
 					</div>
 				</div>
@@ -235,7 +235,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
 						<p class="kicker">Taubat</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan bertobatlah kamu semua kepada Allah, wahai orang-orang yang beriman, agar kamu beruntung."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan bertobatlah kamu semua kepada Allah, wahai orang-orang yang beriman, agar kamu beruntung."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/24/31/" target="_blank" rel="noopener">Baca QS. An-Nur: 31 ↗</a>
 					</div>
 				</div>
@@ -247,7 +247,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
 						<p class="kicker">Taubat</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Sungguh, Allah menyukai orang yang bertobat dan menyukai orang yang menyucikan diri."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="46" class="quote">"Sungguh, Allah menyukai orang yang bertobat dan menyukai orang yang menyucikan diri."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/2/222/" target="_blank" rel="noopener">Baca QS. Al-Baqarah: 222 ↗</a>
 					</div>
 				</div>
@@ -259,7 +259,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
 						<p class="kicker">Taubat</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan hendaklah kamu memohon ampun kepada Tuhanmu dan bertobat kepada-Nya, niscaya Dia akan memberi kenikmatan yang baik kepadamu sampai waktu yang telah ditentukan."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan hendaklah kamu memohon ampun kepada Tuhanmu dan bertobat kepada-Nya, niscaya Dia akan memberi kenikmatan yang baik kepadamu sampai waktu yang telah ditentukan."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/11/3/" target="_blank" rel="noopener">Baca QS. Hud: 3 ↗</a>
 					</div>
 				</div>

--- a/src/tentang-taubat/index.html
+++ b/src/tentang-taubat/index.html
@@ -96,73 +96,86 @@
 		}
 
 		amp-story-page {
-			background-color: #30cfd0;
-			background-image: linear-gradient(135deg, #30cfd0 0%, #330867 100%);
+			background-color: #1d4ed8;
+			background-image: linear-gradient(135deg, #1d4ed8 0%, #4338ca 50%, #6b21a8 100%);
 		}
 
-		amp-story-grid-layer.layer {
-			align-content: center;
-			justify-items: center;
-			padding: 2.5rem 2rem;
+		.page {
+			width: 100%;
+			height: 100%;
+			box-sizing: border-box;
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+			padding: 0.9rem 0.75rem;
 		}
 
 		.panel {
-			background: rgba(0, 0, 0, 0.32);
-			border-radius: 22px;
-			padding: 2rem 1.6rem;
-			max-width: 30rem;
+			display: flex;
+			flex-direction: column;
+			max-height: 100%;
+			box-sizing: border-box;
+			background: rgba(0, 0, 0, 0.36);
+			border-radius: 18px;
+			padding: 1.1rem 1rem;
 		}
 
 		.kicker {
+			flex: 0 0 auto;
 			text-transform: uppercase;
-			letter-spacing: 0.18em;
-			font-size: 0.78rem;
+			letter-spacing: 0.16em;
+			font-size: 0.72rem;
 			opacity: 0.9;
-			margin: 0 0 1rem 0;
+			margin: 0 0 0.7rem 0;
 			text-align: center;
 		}
 
 		.quote {
-			font-size: 1.4rem;
-			line-height: 1.75;
+			flex: 1 1 auto;
+			min-height: 0;
 			text-align: center;
-			margin: 0;
-			font-weight: 400;
+			line-height: 1.5;
 		}
 
 		.ref {
-			margin: 1.4rem 0 0 0;
+			flex: 0 0 auto;
+			display: block;
+			margin: 0.9rem 0 0 0;
 			text-align: center;
-			font-size: 0.95rem;
+			font-size: 0.9rem;
 			font-weight: 700;
-			letter-spacing: 0.04em;
-			opacity: 0.95;
+			letter-spacing: 0.02em;
+			color: #fff;
+			text-decoration: underline;
+			text-underline-offset: 3px;
+		}
+
+		.cover {
+			text-align: center;
 		}
 
 		.cover-title {
-			font-size: 2.9rem;
+			font-size: 2.3rem;
 			line-height: 1.2;
 			font-weight: 700;
-			text-align: center;
 			margin: 0;
 		}
 
 		.cover-sub {
-			margin-top: 1.2rem;
-			font-size: 1.05rem;
-			text-align: center;
+			margin: 1rem 0 0 0;
+			font-size: 1rem;
 			opacity: 0.92;
-			line-height: 1.6;
+			line-height: 1.55;
 		}
 
 		.brand {
 			position: absolute;
-			bottom: 1.4rem;
+			bottom: 1.2rem;
 			left: 0;
 			right: 0;
 			text-align: center;
-			font-size: 0.78rem;
-			letter-spacing: 0.15em;
+			font-size: 0.72rem;
+			letter-spacing: 0.14em;
 			text-transform: uppercase;
 			opacity: 0.85;
 		}
@@ -170,6 +183,7 @@
 
 	<script async src="https://cdn.ampproject.org/v0.js"></script>
 	<script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+	<script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>
 	<script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
 
 </head>
@@ -180,62 +194,74 @@
 		poster-portrait-src="https://www.baca-quran.id/meta-image.png">
 
 		<amp-story-page id="cover">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fade-in">
-					<p class="kicker">Web Stories</p>
-					<h1 class="cover-title">Tentang Taubat</h1>
-					<p class="cover-sub">Kumpulan ayat Al-Quran tentang kembali memohon ampun kepada Allah</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel cover" animate-in="fade-in">
+						<p class="kicker">Web Stories</p>
+						<h1 class="cover-title">Tentang Taubat</h1>
+						<p class="cover-sub">Kumpulan ayat Al-Quran tentang kembali memohon ampun kepada Allah</p>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 			<p class="brand">Baca-Quran.id</p>
 		</amp-story-page>
 
 		<amp-story-page id="az-zumar-53">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-top">
-					<p class="kicker">Taubat</p>
-					<p class="quote">"Wahai hamba-hamba-Ku yang melampaui batas terhadap diri mereka sendiri! Janganlah kamu berputus asa dari rahmat Allah. Sesungguhnya Allah mengampuni dosa-dosa semuanya. Sungguh, Dialah Yang Maha Pengampun, Maha Penyayang."</p>
-					<p class="ref">QS. Az-Zumar: 53</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-top">
+						<p class="kicker">Taubat</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Wahai hamba-hamba-Ku yang melampaui batas terhadap diri mereka sendiri! Janganlah kamu berputus asa dari rahmat Allah. Sesungguhnya Allah mengampuni dosa-dosa semuanya. Sungguh, Dialah Yang Maha Pengampun, Maha Penyayang."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/39/53/" target="_blank" rel="noopener">Baca QS. Az-Zumar: 53 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="at-tahrim-8">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-bottom">
-					<p class="kicker">Taubat</p>
-					<p class="quote">"Wahai orang-orang yang beriman! Bertobatlah kepada Allah dengan tobat yang semurni-murninya, mudah-mudahan Tuhanmu akan menghapus kesalahan-kesalahanmu."</p>
-					<p class="ref">QS. At-Tahrim: 8</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-bottom">
+						<p class="kicker">Taubat</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Wahai orang-orang yang beriman! Bertobatlah kepada Allah dengan tobat yang semurni-murninya, mudah-mudahan Tuhanmu akan menghapus kesalahan-kesalahanmu."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/66/8/" target="_blank" rel="noopener">Baca QS. At-Tahrim: 8 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="an-nur-31">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-top">
-					<p class="kicker">Taubat</p>
-					<p class="quote">"Dan bertobatlah kamu semua kepada Allah, wahai orang-orang yang beriman, agar kamu beruntung."</p>
-					<p class="ref">QS. An-Nur: 31</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-top">
+						<p class="kicker">Taubat</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan bertobatlah kamu semua kepada Allah, wahai orang-orang yang beriman, agar kamu beruntung."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/24/31/" target="_blank" rel="noopener">Baca QS. An-Nur: 31 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="al-baqarah-222">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-bottom">
-					<p class="kicker">Taubat</p>
-					<p class="quote">"Sungguh, Allah menyukai orang yang bertobat dan menyukai orang yang menyucikan diri."</p>
-					<p class="ref">QS. Al-Baqarah: 222</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-bottom">
+						<p class="kicker">Taubat</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Sungguh, Allah menyukai orang yang bertobat dan menyukai orang yang menyucikan diri."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/2/222/" target="_blank" rel="noopener">Baca QS. Al-Baqarah: 222 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="hud-3">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-top">
-					<p class="kicker">Taubat</p>
-					<p class="quote">"Dan hendaklah kamu memohon ampun kepada Tuhanmu dan bertobat kepada-Nya, niscaya Dia akan memberi kenikmatan yang baik kepadamu sampai waktu yang telah ditentukan."</p>
-					<p class="ref">QS. Hud: 3</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-top">
+						<p class="kicker">Taubat</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan hendaklah kamu memohon ampun kepada Tuhanmu dan bertobat kepada-Nya, niscaya Dia akan memberi kenikmatan yang baik kepadamu sampai waktu yang telah ditentukan."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/11/3/" target="_blank" rel="noopener">Baca QS. Hud: 3 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>

--- a/src/tentang-tawakal/index.html
+++ b/src/tentang-tawakal/index.html
@@ -96,73 +96,86 @@
 		}
 
 		amp-story-page {
-			background-color: #0ba360;
-			background-image: linear-gradient(135deg, #0ba360 0%, #3cba92 100%);
+			background-color: #10b981;
+			background-image: linear-gradient(135deg, #10b981 0%, #14b8a6 50%, #06b6d4 100%);
 		}
 
-		amp-story-grid-layer.layer {
-			align-content: center;
-			justify-items: center;
-			padding: 2.5rem 2rem;
+		.page {
+			width: 100%;
+			height: 100%;
+			box-sizing: border-box;
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+			padding: 0.9rem 0.75rem;
 		}
 
 		.panel {
-			background: rgba(0, 0, 0, 0.32);
-			border-radius: 22px;
-			padding: 2rem 1.6rem;
-			max-width: 30rem;
+			display: flex;
+			flex-direction: column;
+			max-height: 100%;
+			box-sizing: border-box;
+			background: rgba(0, 0, 0, 0.36);
+			border-radius: 18px;
+			padding: 1.1rem 1rem;
 		}
 
 		.kicker {
+			flex: 0 0 auto;
 			text-transform: uppercase;
-			letter-spacing: 0.18em;
-			font-size: 0.78rem;
+			letter-spacing: 0.16em;
+			font-size: 0.72rem;
 			opacity: 0.9;
-			margin: 0 0 1rem 0;
+			margin: 0 0 0.7rem 0;
 			text-align: center;
 		}
 
 		.quote {
-			font-size: 1.4rem;
-			line-height: 1.75;
+			flex: 1 1 auto;
+			min-height: 0;
 			text-align: center;
-			margin: 0;
-			font-weight: 400;
+			line-height: 1.5;
 		}
 
 		.ref {
-			margin: 1.4rem 0 0 0;
+			flex: 0 0 auto;
+			display: block;
+			margin: 0.9rem 0 0 0;
 			text-align: center;
-			font-size: 0.95rem;
+			font-size: 0.9rem;
 			font-weight: 700;
-			letter-spacing: 0.04em;
-			opacity: 0.95;
+			letter-spacing: 0.02em;
+			color: #fff;
+			text-decoration: underline;
+			text-underline-offset: 3px;
+		}
+
+		.cover {
+			text-align: center;
 		}
 
 		.cover-title {
-			font-size: 2.9rem;
+			font-size: 2.3rem;
 			line-height: 1.2;
 			font-weight: 700;
-			text-align: center;
 			margin: 0;
 		}
 
 		.cover-sub {
-			margin-top: 1.2rem;
-			font-size: 1.05rem;
-			text-align: center;
+			margin: 1rem 0 0 0;
+			font-size: 1rem;
 			opacity: 0.92;
-			line-height: 1.6;
+			line-height: 1.55;
 		}
 
 		.brand {
 			position: absolute;
-			bottom: 1.4rem;
+			bottom: 1.2rem;
 			left: 0;
 			right: 0;
 			text-align: center;
-			font-size: 0.78rem;
-			letter-spacing: 0.15em;
+			font-size: 0.72rem;
+			letter-spacing: 0.14em;
 			text-transform: uppercase;
 			opacity: 0.85;
 		}
@@ -170,6 +183,7 @@
 
 	<script async src="https://cdn.ampproject.org/v0.js"></script>
 	<script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+	<script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>
 	<script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
 
 </head>
@@ -180,62 +194,74 @@
 		poster-portrait-src="https://www.baca-quran.id/meta-image.png">
 
 		<amp-story-page id="cover">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fade-in">
-					<p class="kicker">Web Stories</p>
-					<h1 class="cover-title">Tentang Tawakal</h1>
-					<p class="cover-sub">Kumpulan ayat Al-Quran tentang berserah diri kepada Allah</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel cover" animate-in="fade-in">
+						<p class="kicker">Web Stories</p>
+						<h1 class="cover-title">Tentang Tawakal</h1>
+						<p class="cover-sub">Kumpulan ayat Al-Quran tentang berserah diri kepada Allah</p>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 			<p class="brand">Baca-Quran.id</p>
 		</amp-story-page>
 
 		<amp-story-page id="at-talaq-3">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-top">
-					<p class="kicker">Tawakal</p>
-					<p class="quote">"Dan barangsiapa bertawakal kepada Allah, niscaya Allah akan mencukupkan (keperluan)nya. Sesungguhnya Allah melaksanakan urusan-Nya."</p>
-					<p class="ref">QS. At-Talaq: 3</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-top">
+						<p class="kicker">Tawakal</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan barangsiapa bertawakal kepada Allah, niscaya Allah akan mencukupkan (keperluan)nya. Sesungguhnya Allah melaksanakan urusan-Nya."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/65/3/" target="_blank" rel="noopener">Baca QS. At-Talaq: 3 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="ali-imran-159">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-bottom">
-					<p class="kicker">Tawakal</p>
-					<p class="quote">"Kemudian, apabila engkau telah membulatkan tekad, maka bertawakallah kepada Allah. Sungguh, Allah mencintai orang yang bertawakal."</p>
-					<p class="ref">QS. Ali 'Imran: 159</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-bottom">
+						<p class="kicker">Tawakal</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Kemudian, apabila engkau telah membulatkan tekad, maka bertawakallah kepada Allah. Sungguh, Allah mencintai orang yang bertawakal."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/3/159/" target="_blank" rel="noopener">Baca QS. Ali 'Imran: 159 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="al-anfal-2">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-top">
-					<p class="kicker">Tawakal</p>
-					<p class="quote">"Sesungguhnya orang-orang yang beriman adalah mereka yang apabila disebut nama Allah gemetar hatinya, dan apabila dibacakan ayat-ayat-Nya bertambah (kuat) imannya, dan hanya kepada Tuhan mereka bertawakal."</p>
-					<p class="ref">QS. Al-Anfal: 2</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-top">
+						<p class="kicker">Tawakal</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Sesungguhnya orang-orang yang beriman adalah mereka yang apabila disebut nama Allah gemetar hatinya, dan apabila dibacakan ayat-ayat-Nya bertambah (kuat) imannya, dan hanya kepada Tuhan mereka bertawakal."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/8/2/" target="_blank" rel="noopener">Baca QS. Al-Anfal: 2 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="al-maidah-23">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-bottom">
-					<p class="kicker">Tawakal</p>
-					<p class="quote">"Dan bertawakallah kamu hanya kepada Allah, jika kamu orang-orang beriman."</p>
-					<p class="ref">QS. Al-Ma'idah: 23</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-bottom">
+						<p class="kicker">Tawakal</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan bertawakallah kamu hanya kepada Allah, jika kamu orang-orang beriman."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/5/23/" target="_blank" rel="noopener">Baca QS. Al-Ma'idah: 23 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-story-page id="hud-88">
-			<amp-story-grid-layer template="vertical" class="layer">
-				<div class="panel" animate-in="fly-in-top">
-					<p class="kicker">Tawakal</p>
-					<p class="quote">"Dan tidak ada (manfaat) taufik bagiku melainkan dengan (pertolongan) Allah. Hanya kepada-Nya aku bertawakal dan hanya kepada-Nya aku kembali."</p>
-					<p class="ref">QS. Hud: 88</p>
+			<amp-story-grid-layer template="fill">
+				<div class="page">
+					<div class="panel" animate-in="fly-in-top">
+						<p class="kicker">Tawakal</p>
+						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan tidak ada (manfaat) taufik bagiku melainkan dengan (pertolongan) Allah. Hanya kepada-Nya aku bertawakal dan hanya kepada-Nya aku kembali."</amp-fit-text>
+						<a class="ref" href="https://www.baca-quran.id/surah/11/88/" target="_blank" rel="noopener">Baca QS. Hud: 88 ↗</a>
+					</div>
 				</div>
 			</amp-story-grid-layer>
 		</amp-story-page>

--- a/src/tentang-tawakal/index.html
+++ b/src/tentang-tawakal/index.html
@@ -211,7 +211,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
 						<p class="kicker">Tawakal</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan barangsiapa bertawakal kepada Allah, niscaya Allah akan mencukupkan (keperluan)nya. Sesungguhnya Allah melaksanakan urusan-Nya."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan barangsiapa bertawakal kepada Allah, niscaya Allah akan mencukupkan (keperluan)nya. Sesungguhnya Allah melaksanakan urusan-Nya."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/65/3/" target="_blank" rel="noopener">Baca QS. At-Talaq: 3 ↗</a>
 					</div>
 				</div>
@@ -223,7 +223,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
 						<p class="kicker">Tawakal</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Kemudian, apabila engkau telah membulatkan tekad, maka bertawakallah kepada Allah. Sungguh, Allah mencintai orang yang bertawakal."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Kemudian, apabila engkau telah membulatkan tekad, maka bertawakallah kepada Allah. Sungguh, Allah mencintai orang yang bertawakal."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/3/159/" target="_blank" rel="noopener">Baca QS. Ali 'Imran: 159 ↗</a>
 					</div>
 				</div>
@@ -235,7 +235,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
 						<p class="kicker">Tawakal</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Sesungguhnya orang-orang yang beriman adalah mereka yang apabila disebut nama Allah gemetar hatinya, dan apabila dibacakan ayat-ayat-Nya bertambah (kuat) imannya, dan hanya kepada Tuhan mereka bertawakal."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="28" class="quote">"Sesungguhnya orang-orang yang beriman adalah mereka yang apabila disebut nama Allah gemetar hatinya, dan apabila dibacakan ayat-ayat-Nya bertambah (kuat) imannya, dan hanya kepada Tuhan mereka bertawakal."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/8/2/" target="_blank" rel="noopener">Baca QS. Al-Anfal: 2 ↗</a>
 					</div>
 				</div>
@@ -247,7 +247,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
 						<p class="kicker">Tawakal</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan bertawakallah kamu hanya kepada Allah, jika kamu orang-orang beriman."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="46" class="quote">"Dan bertawakallah kamu hanya kepada Allah, jika kamu orang-orang beriman."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/5/23/" target="_blank" rel="noopener">Baca QS. Al-Ma'idah: 23 ↗</a>
 					</div>
 				</div>
@@ -259,7 +259,7 @@
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
 						<p class="kicker">Tawakal</p>
-						<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30" class="quote">"Dan tidak ada (manfaat) taufik bagiku melainkan dengan (pertolongan) Allah. Hanya kepada-Nya aku bertawakal dan hanya kepada-Nya aku kembali."</amp-fit-text>
+						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan tidak ada (manfaat) taufik bagiku melainkan dengan (pertolongan) Allah. Hanya kepada-Nya aku bertawakal dan hanya kepada-Nya aku kembali."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/11/88/" target="_blank" rel="noopener">Baca QS. Hud: 88 ↗</a>
 					</div>
 				</div>


### PR DESCRIPTION
Follow-up corrections to the 7 gradient stories from #35.

## Changes

### 1. Gradients sourced from [hypercolor.dev](https://hypercolor.dev/)
All 10 card/story gradients now use hypercolor presets — 3-stop Tailwind `from / via / to` stops at `135deg` — for a more vibrant, cohesive look. Each story page's background matches its card.

### 2. Clickable verse links
Every ayat reference is now a link to that verse on Baca-Quran.id, using the site's URL pattern `https://www.baca-quran.id/surah/{surah}/{ayat}/` (verified against the live site). Rendered as e.g. `Baca QS. Al-Isra: 23 ↗`.

### 3. Long verses stay visible (`amp-fit-text`)
Verse text is wrapped in `<amp-fit-text layout="flex-item" min-font-size="13" max-font-size="30">`, so long ayat (e.g. Al-Isra 23, Luqman 14, Al-Bayyinah 5) automatically scale down to fit their panel instead of overflowing and getting clipped/invisible. Short verses still render large.

### 4. Tighter layout
Reduced page padding (`0.9rem 0.75rem`) and panel padding (`1.1rem 1rem`) to give the verse text more room.

### Docs
`AGENTS.md` now records the rule to **always pick gradients from hypercolor.dev**, plus the new story-page conventions (`amp-fit-text` for verses, Baca-Quran.id verse links).

## Notes
- AMP runtime scripts (including the newly added `amp-fit-text`) are loaded from the unversioned `cdn.ampproject.org` without SRI — this is required by AMP and matches the rest of the repo.

## Verification
- `pnpm run format:check` (CI gate) — passes.
- `pnpm run build` — all 10 stories + generated index/sitemap produced in `dist/`.

https://claude.ai/code/session_01Dq9BZiRtEMYQwXK7BL8LG8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dq9BZiRtEMYQwXK7BL8LG8)_