### PR TITLE
Remove repeated category label from verse pages

### DIFF
--- a/src/tentang-berbakti-kepada-orang-tua/index.html
+++ b/src/tentang-berbakti-kepada-orang-tua/index.html
@@ -213,7 +213,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
-						<p class="kicker">Birrul Walidain</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="24" class="quote">"Dan Tuhanmu telah memerintahkan agar kamu jangan menyembah selain Dia dan hendaklah berbuat baik kepada ibu bapak. Jika salah seorang di antara keduanya atau kedua-duanya sampai berusia lanjut dalam pemeliharaanmu, maka janganlah sekali-kali engkau mengatakan kepada keduanya perkataan 'ah' dan janganlah engkau membentak keduanya, dan ucapkanlah kepada keduanya perkataan yang baik."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/17/23/" target="_blank" rel="noopener">Baca QS. Al-Isra: 23 ↗</a>
 					</div>
@@ -225,7 +224,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
-						<p class="kicker">Birrul Walidain</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="28" class="quote">"Dan rendahkanlah dirimu terhadap keduanya dengan penuh kasih sayang dan ucapkanlah, 'Wahai Tuhanku! Sayangilah keduanya sebagaimana mereka berdua telah mendidik aku pada waktu kecil.'"</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/17/24/" target="_blank" rel="noopener">Baca QS. Al-Isra: 24 ↗</a>
 					</div>
@@ -237,7 +235,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
-						<p class="kicker">Birrul Walidain</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="28" class="quote">"Dan Kami perintahkan kepada manusia (agar berbuat baik) kepada kedua orang tuanya. Ibunya telah mengandungnya dalam keadaan lemah yang bertambah-tambah, dan menyapihnya dalam usia dua tahun. Bersyukurlah kepada-Ku dan kepada kedua orang tuamu. Hanya kepada Aku kembalimu."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/31/14/" target="_blank" rel="noopener">Baca QS. Luqman: 14 ↗</a>
 					</div>
@@ -249,7 +246,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
-						<p class="kicker">Birrul Walidain</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="46" class="quote">"Dan Kami wajibkan kepada manusia (berbuat) kebaikan kepada kedua orang tuanya."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/29/8/" target="_blank" rel="noopener">Baca QS. Al-Ankabut: 8 ↗</a>
 					</div>
@@ -261,7 +257,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
-						<p class="kicker">Birrul Walidain</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="28" class="quote">"Dan sembahlah Allah dan janganlah kamu mempersekutukan-Nya dengan sesuatu apa pun. Dan berbuat baiklah kepada kedua orang tua, karib kerabat, anak-anak yatim, dan orang-orang miskin."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/4/36/" target="_blank" rel="noopener">Baca QS. An-Nisa: 36 ↗</a>
 					</div>

--- a/src/tentang-ikhlas/index.html
+++ b/src/tentang-ikhlas/index.html
@@ -213,7 +213,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
-						<p class="kicker">Ikhlas</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="28" class="quote">"Padahal mereka hanya diperintah menyembah Allah dengan ikhlas menaati-Nya semata-mata karena (menjalankan) agama, dan juga agar melaksanakan salat dan menunaikan zakat; dan yang demikian itulah agama yang lurus."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/98/5/" target="_blank" rel="noopener">Baca QS. Al-Bayyinah: 5 ↗</a>
 					</div>
@@ -225,7 +224,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
-						<p class="kicker">Ikhlas</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Sesungguhnya Kami menurunkan Kitab (Al-Qur'an) kepadamu dengan (membawa) kebenaran. Maka sembahlah Allah dengan tulus ikhlas beragama kepada-Nya."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/39/2/" target="_blank" rel="noopener">Baca QS. Az-Zumar: 2 ↗</a>
 					</div>
@@ -237,7 +235,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
-						<p class="kicker">Ikhlas</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Katakanlah (Muhammad), 'Sesungguhnya salatku, ibadahku, hidupku dan matiku hanyalah untuk Allah, Tuhan seluruh alam.'"</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/6/162/" target="_blank" rel="noopener">Baca QS. Al-An'am: 162 ↗</a>
 					</div>
@@ -249,7 +246,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
-						<p class="kicker">Ikhlas</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Katakanlah, 'Sesungguhnya aku diperintahkan menyembah Allah dengan tulus ikhlas beragama kepada-Nya.'"</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/39/11/" target="_blank" rel="noopener">Baca QS. Az-Zumar: 11 ↗</a>
 					</div>
@@ -261,7 +257,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
-						<p class="kicker">Ikhlas</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Maka barangsiapa mengharap pertemuan dengan Tuhannya, hendaklah dia mengerjakan kebajikan dan janganlah dia mempersekutukan dengan sesuatu pun dalam beribadah kepada Tuhannya."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/18/110/" target="_blank" rel="noopener">Baca QS. Al-Kahf: 110 ↗</a>
 					</div>

--- a/src/tentang-jujur/index.html
+++ b/src/tentang-jujur/index.html
@@ -213,7 +213,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
-						<p class="kicker">Jujur</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Wahai orang-orang yang beriman! Bertakwalah kepada Allah, dan bersamalah kamu dengan orang-orang yang benar."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/9/119/" target="_blank" rel="noopener">Baca QS. At-Taubah: 119 ↗</a>
 					</div>
@@ -225,7 +224,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
-						<p class="kicker">Jujur</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Wahai orang-orang yang beriman! Bertakwalah kamu kepada Allah dan ucapkanlah perkataan yang benar,"</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/33/70/" target="_blank" rel="noopener">Baca QS. Al-Ahzab: 70 ↗</a>
 					</div>
@@ -237,7 +235,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
-						<p class="kicker">Jujur</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"niscaya Allah akan memperbaiki amal-amalmu dan mengampuni dosa-dosamu. Dan barangsiapa menaati Allah dan Rasul-Nya, maka sungguh, dia menang dengan kemenangan yang agung."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/33/71/" target="_blank" rel="noopener">Baca QS. Al-Ahzab: 71 ↗</a>
 					</div>
@@ -249,7 +246,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
-						<p class="kicker">Jujur</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan orang yang membawa kebenaran (Muhammad) dan orang yang membenarkannya, mereka itulah orang yang bertakwa."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/39/33/" target="_blank" rel="noopener">Baca QS. Az-Zumar: 33 ↗</a>
 					</div>
@@ -261,7 +257,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
-						<p class="kicker">Jujur</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Inilah saat orang yang benar memperoleh manfaat dari kebenarannya. Mereka memperoleh surga yang mengalir di bawahnya sungai-sungai, mereka kekal di dalamnya selama-lamanya."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/5/119/" target="_blank" rel="noopener">Baca QS. Al-Ma'idah: 119 ↗</a>
 					</div>

--- a/src/tentang-silaturahmi/index.html
+++ b/src/tentang-silaturahmi/index.html
@@ -213,7 +213,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
-						<p class="kicker">Silaturahmi</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan bertakwalah kepada Allah yang dengan nama-Nya kamu saling meminta, dan (peliharalah) hubungan kekeluargaan. Sesungguhnya Allah selalu menjaga dan mengawasimu."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/4/1/" target="_blank" rel="noopener">Baca QS. An-Nisa: 1 ↗</a>
 					</div>
@@ -225,7 +224,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
-						<p class="kicker">Silaturahmi</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan orang-orang yang menghubungkan apa yang diperintahkan Allah agar dihubungkan, dan mereka takut kepada Tuhannya dan takut kepada hisab yang buruk."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/13/21/" target="_blank" rel="noopener">Baca QS. Ar-Ra'd: 21 ↗</a>
 					</div>
@@ -237,7 +235,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
-						<p class="kicker">Silaturahmi</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Sesungguhnya Allah menyuruh (kamu) berlaku adil dan berbuat kebajikan, memberi bantuan kepada kerabat, dan Dia melarang (melakukan) perbuatan keji, kemungkaran, dan permusuhan."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/16/90/" target="_blank" rel="noopener">Baca QS. An-Nahl: 90 ↗</a>
 					</div>
@@ -249,7 +246,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
-						<p class="kicker">Silaturahmi</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Maka apakah sekiranya kamu berkuasa, kamu akan berbuat kerusakan di bumi dan memutuskan hubungan kekeluargaan?"</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/47/22/" target="_blank" rel="noopener">Baca QS. Muhammad: 22 ↗</a>
 					</div>
@@ -261,7 +257,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
-						<p class="kicker">Silaturahmi</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan berikanlah haknya kepada kerabat dekat, juga kepada orang miskin dan orang yang dalam perjalanan; dan janganlah kamu menghambur-hamburkan (hartamu) secara boros."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/17/26/" target="_blank" rel="noopener">Baca QS. Al-Isra: 26 ↗</a>
 					</div>

--- a/src/tentang-syukur/index.html
+++ b/src/tentang-syukur/index.html
@@ -213,7 +213,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
-						<p class="kicker">Syukur</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Sesungguhnya jika kamu bersyukur, niscaya Aku akan menambah (nikmat) kepadamu, tetapi jika kamu mengingkari (nikmat-Ku), maka sesungguhnya azab-Ku sangat pedih."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/14/7/" target="_blank" rel="noopener">Baca QS. Ibrahim: 7 ↗</a>
 					</div>
@@ -225,7 +224,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
-						<p class="kicker">Syukur</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Maka ingatlah kepada-Ku, Aku pun akan ingat kepadamu. Bersyukurlah kepada-Ku, dan janganlah kamu ingkar kepada-Ku."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/2/152/" target="_blank" rel="noopener">Baca QS. Al-Baqarah: 152 ↗</a>
 					</div>
@@ -237,7 +235,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
-						<p class="kicker">Syukur</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan jika kamu menghitung nikmat Allah, niscaya kamu tidak akan mampu menghitungnya. Sungguh, Allah benar-benar Maha Pengampun, Maha Penyayang."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/16/18/" target="_blank" rel="noopener">Baca QS. An-Nahl: 18 ↗</a>
 					</div>
@@ -249,7 +246,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
-						<p class="kicker">Syukur</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Barangsiapa bersyukur (kepada Allah), maka sesungguhnya dia bersyukur untuk dirinya sendiri; dan barangsiapa tidak bersyukur, maka sesungguhnya Allah Mahakaya, Maha Terpuji."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/31/12/" target="_blank" rel="noopener">Baca QS. Luqman: 12 ↗</a>
 					</div>
@@ -261,7 +257,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
-						<p class="kicker">Syukur</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan Dia tidak meridai kekafiran bagi hamba-Nya. Jika kamu bersyukur, Dia meridai kesyukuranmu itu."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/39/7/" target="_blank" rel="noopener">Baca QS. Az-Zumar: 7 ↗</a>
 					</div>

--- a/src/tentang-taubat/index.html
+++ b/src/tentang-taubat/index.html
@@ -213,7 +213,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
-						<p class="kicker">Taubat</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="28" class="quote">"Wahai hamba-hamba-Ku yang melampaui batas terhadap diri mereka sendiri! Janganlah kamu berputus asa dari rahmat Allah. Sesungguhnya Allah mengampuni dosa-dosa semuanya. Sungguh, Dialah Yang Maha Pengampun, Maha Penyayang."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/39/53/" target="_blank" rel="noopener">Baca QS. Az-Zumar: 53 ↗</a>
 					</div>
@@ -225,7 +224,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
-						<p class="kicker">Taubat</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Wahai orang-orang yang beriman! Bertobatlah kepada Allah dengan tobat yang semurni-murninya, mudah-mudahan Tuhanmu akan menghapus kesalahan-kesalahanmu."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/66/8/" target="_blank" rel="noopener">Baca QS. At-Tahrim: 8 ↗</a>
 					</div>
@@ -237,7 +235,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
-						<p class="kicker">Taubat</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan bertobatlah kamu semua kepada Allah, wahai orang-orang yang beriman, agar kamu beruntung."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/24/31/" target="_blank" rel="noopener">Baca QS. An-Nur: 31 ↗</a>
 					</div>
@@ -249,7 +246,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
-						<p class="kicker">Taubat</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="46" class="quote">"Sungguh, Allah menyukai orang yang bertobat dan menyukai orang yang menyucikan diri."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/2/222/" target="_blank" rel="noopener">Baca QS. Al-Baqarah: 222 ↗</a>
 					</div>
@@ -261,7 +257,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
-						<p class="kicker">Taubat</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan hendaklah kamu memohon ampun kepada Tuhanmu dan bertobat kepada-Nya, niscaya Dia akan memberi kenikmatan yang baik kepadamu sampai waktu yang telah ditentukan."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/11/3/" target="_blank" rel="noopener">Baca QS. Hud: 3 ↗</a>
 					</div>

--- a/src/tentang-tawakal/index.html
+++ b/src/tentang-tawakal/index.html
@@ -213,7 +213,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
-						<p class="kicker">Tawakal</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan barangsiapa bertawakal kepada Allah, niscaya Allah akan mencukupkan (keperluan)nya. Sesungguhnya Allah melaksanakan urusan-Nya."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/65/3/" target="_blank" rel="noopener">Baca QS. At-Talaq: 3 ↗</a>
 					</div>
@@ -225,7 +224,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
-						<p class="kicker">Tawakal</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Kemudian, apabila engkau telah membulatkan tekad, maka bertawakallah kepada Allah. Sungguh, Allah mencintai orang yang bertawakal."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/3/159/" target="_blank" rel="noopener">Baca QS. Ali 'Imran: 159 ↗</a>
 					</div>
@@ -237,7 +235,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
-						<p class="kicker">Tawakal</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="28" class="quote">"Sesungguhnya orang-orang yang beriman adalah mereka yang apabila disebut nama Allah gemetar hatinya, dan apabila dibacakan ayat-ayat-Nya bertambah (kuat) imannya, dan hanya kepada Tuhan mereka bertawakal."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/8/2/" target="_blank" rel="noopener">Baca QS. Al-Anfal: 2 ↗</a>
 					</div>
@@ -249,7 +246,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-bottom">
-						<p class="kicker">Tawakal</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="46" class="quote">"Dan bertawakallah kamu hanya kepada Allah, jika kamu orang-orang beriman."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/5/23/" target="_blank" rel="noopener">Baca QS. Al-Ma'idah: 23 ↗</a>
 					</div>
@@ -261,7 +257,6 @@
 			<amp-story-grid-layer template="fill">
 				<div class="page">
 					<div class="panel" animate-in="fly-in-top">
-						<p class="kicker">Tawakal</p>
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan tidak ada (manfaat) taufik bagiku melainkan dengan (pertolongan) Allah. Hanya kepada-Nya aku bertawakal dan hanya kepada-Nya aku kembali."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/11/88/" target="_blank" rel="noopener">Baca QS. Hud: 88 ↗</a>
 					</div>


### PR DESCRIPTION
Removes the repeated category label (the kicker, e.g. "Syukur" / "Birrul Walidain") from each **verse page**. The topic is already established by the cover/opening page, so repeating it on every verse is redundant.

- Verse pages now show just the verse + the Baca-Quran.id link.
- The cover keeps its `Web Stories` kicker and topic title.
- Net change: 35 lines removed (5 verses × 7 stories), nothing else touched.

## Stacked PR
This branches off `claude/fix-story-text-visibility` (PR #37), since it builds on those validated stories. **Merge #37 first**; GitHub will then retarget this PR to `master`.

## Verification
- `pnpm run validate` — all 10 AMP files PASS.
- `pnpm run format:check` and `pnpm run build` pass.

https://claude.ai/code/session_01Dq9BZiRtEMYQwXK7BL8LG8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dq9BZiRtEMYQwXK7BL8LG8)_