### PR TITLE
Restore cursive content fonts on gradient stories, themed per topic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,10 @@ scrim, so any vibrant hypercolor preset keeps white text readable.
      (`https://www.baca-quran.id/surah/<surahNumber>/<ayatNumber>/`).
    - Load `amp-fit-text` via
      `<script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>`.
+   - Give it a **cursive content font** and a **themed entrance animation** —
+     these are required parts of the house style, see
+     [Typography](#typography--cursive-is-the-contents-signature-look) and
+     [Motion](#motion--themed-entrance-animations) below.
 
    (Older stories such as `src/tentang-sabar/index.html` instead pull full-bleed
    images from `https://www.baca-quran.id/stories-content/<slug>/`; either style
@@ -123,6 +127,79 @@ and pick the cap by character length:
 
 So a one-line verse can fill the panel at ~46px while a long verse settles
 smaller — each page is sized to its own content, not a single fixed value.
+
+### Typography — cursive is the content's signature look
+
+The verse content is meant to feel **cursive/handwritten** — that is the
+deliberate house style, carried over from the original 2020 stories (which
+used Pacifico + Merienda One). Do **not** ship a gradient story with a plain
+serif/sans body; that reads as a regression. Rules:
+
+- **Load fonts per page.** Each story loads only its own fonts via an
+  AMP-valid stylesheet `<link>` in `<head>`, placed right after the
+  `<link rel="canonical">` (with `preconnect` hints to
+  `fonts.googleapis.com` / `fonts.gstatic.com`). Google Fonts is an
+  AMP-allowed font provider, so this passes the validator.
+- **One pairing per theme:** a *decorative* script for `.cover-title` plus a
+  **readable** handwriting/script for `.quote` (the verse body). Set
+  `font-family: '<Font>', cursive;` on both.
+- **Body readability is non-negotiable.** Verses can be long and sit on a
+  dark scrim, so the `.quote` face must stay legible at paragraph length —
+  use readable scripts (Merienda, Caveat, Courgette, Kalam). Reserve the
+  ornamental faces (Pacifico, Great Vibes, Sacramento, Parisienne, Lobster,
+  Kaushan Script, Satisfy) for the short `.cover-title` only. Give `.quote`
+  a little more room — `line-height: ~1.6` and `font-weight: 500–600`;
+  `.cover-title` reads best at `font-weight: 400`.
+- **Default pairing:** Pacifico (title) + Merienda (body). Use it unless the
+  theme clearly calls for its own character.
+- **Keep UI labels clean.** Don't put the cursive face on `.kicker`, `.ref`,
+  or `.brand` — those small labels stay in the system fallback for legibility.
+
+Current per-theme pairings (cover title / verse body):
+
+| Story | Cover title | Verse body |
+| --- | --- | --- |
+| tentang-syukur | Pacifico | Merienda |
+| tentang-tawakal | Satisfy | Caveat |
+| tentang-ikhlas | Great Vibes | Courgette |
+| tentang-taubat | Parisienne | Kalam |
+| tentang-jujur | Kaushan Script | Caveat |
+| tentang-berbakti-kepada-orang-tua | Sacramento | Courgette |
+| tentang-silaturahmi | Lobster | Merienda |
+
+### Motion — themed entrance animations
+
+AMP web stories animate elements **in** (`animate-in`) as a page becomes
+active; the page swipe itself is the "exit" — there is **no per-element exit
+animation**, so don't promise one. Give each story a small motion identity:
+
+- **Signature entrance + tempo + easing.** Pick an `animate-in` preset that
+  matches the theme's mood and tune `animate-in-duration` /
+  `animate-in-timing-function` to set the tempo — calm themes (tawakal)
+  breathe slower (~1.2s, `ease-in-out`); direct themes (jujur) snap in
+  (~0.6s, `ease-out`).
+- **Stagger the cover.** Animate the cover's three children (kicker → title →
+  subtitle) with increasing `animate-in-delay` for a layered reveal — animate
+  the children, not the wrapping `.panel`.
+- **Alternate verse panels.** Use two complementary entrances (A/B) across
+  consecutive verse pages so they don't all move identically.
+- **Valid presets** (the validator rejects unknown names): `fade-in`,
+  `fly-in-{top,bottom,left,right}`, `pan-{up,down,left,right}`, `zoom-in`,
+  `zoom-out`, `rotate-in-{left,right}`, `twirl-in`, `whoosh-in-{left,right}`,
+  `drop`, `pulse`.
+
+Current per-theme motion (cover / verse A / verse B, tempo):
+
+| Story | Cover | Verse A / B | Tempo |
+| --- | --- | --- | --- |
+| tentang-syukur | zoom-in | fly-in-bottom / zoom-in | 0.8s ease-out |
+| tentang-tawakal | fade-in | pan-up / fade-in | 1.2s ease-in-out |
+| tentang-ikhlas | twirl-in | rotate-in-left / rotate-in-right | 1s ease-out |
+| tentang-taubat | fly-in-bottom | fly-in-bottom / fade-in | 1s ease-in-out |
+| tentang-jujur | whoosh-in-right | whoosh-in-left / whoosh-in-right | 0.6s ease-out |
+| tentang-berbakti-kepada-orang-tua | drop | fly-in-bottom / drop | 0.9s ease-out |
+| tentang-silaturahmi | fly-in-left | fly-in-left / fly-in-right | 0.9s ease-out |
+
 3. **Sync the landing page** — run `pnpm run generate:index` and commit
    `src/index.html`. This only rewrites the cards between the
    `<!-- stories:start -->` / `<!-- stories:end -->` markers inside

--- a/src/tentang-berbakti-kepada-orang-tua/index.html
+++ b/src/tentang-berbakti-kepada-orang-tua/index.html
@@ -203,10 +203,10 @@
 		<amp-story-page id="cover">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel cover" animate-in="fade-in">
-						<p class="kicker">Web Stories</p>
-						<h1 class="cover-title">Berbakti kepada Orang Tua</h1>
-						<p class="cover-sub">Kumpulan ayat Al-Quran tentang berbuat baik kepada ibu dan bapak</p>
+					<div class="panel cover">
+						<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Web Stories</p>
+						<h1 class="cover-title" animate-in="drop" animate-in-duration="0.9s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Berbakti kepada Orang Tua</h1>
+						<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Kumpulan ayat Al-Quran tentang berbuat baik kepada ibu dan bapak</p>
 					</div>
 				</div>
 			</amp-story-grid-layer>
@@ -218,7 +218,7 @@
 		<amp-story-page id="al-isra-23">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-top">
+					<div class="panel" animate-in="fly-in-bottom" animate-in-duration="0.9s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="24" class="quote">"Dan Tuhanmu telah memerintahkan agar kamu jangan menyembah selain Dia dan hendaklah berbuat baik kepada ibu bapak. Jika salah seorang di antara keduanya atau kedua-duanya sampai berusia lanjut dalam pemeliharaanmu, maka janganlah sekali-kali engkau mengatakan kepada keduanya perkataan 'ah' dan janganlah engkau membentak keduanya, dan ucapkanlah kepada keduanya perkataan yang baik."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/17/23/" target="_blank" rel="noopener">Baca QS. Al-Isra: 23 ↗</a>
 					</div>
@@ -229,7 +229,7 @@
 		<amp-story-page id="al-isra-24">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-bottom">
+					<div class="panel" animate-in="drop" animate-in-duration="0.9s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="28" class="quote">"Dan rendahkanlah dirimu terhadap keduanya dengan penuh kasih sayang dan ucapkanlah, 'Wahai Tuhanku! Sayangilah keduanya sebagaimana mereka berdua telah mendidik aku pada waktu kecil.'"</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/17/24/" target="_blank" rel="noopener">Baca QS. Al-Isra: 24 ↗</a>
 					</div>
@@ -240,7 +240,7 @@
 		<amp-story-page id="luqman-14">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-top">
+					<div class="panel" animate-in="fly-in-bottom" animate-in-duration="0.9s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="28" class="quote">"Dan Kami perintahkan kepada manusia (agar berbuat baik) kepada kedua orang tuanya. Ibunya telah mengandungnya dalam keadaan lemah yang bertambah-tambah, dan menyapihnya dalam usia dua tahun. Bersyukurlah kepada-Ku dan kepada kedua orang tuamu. Hanya kepada Aku kembalimu."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/31/14/" target="_blank" rel="noopener">Baca QS. Luqman: 14 ↗</a>
 					</div>
@@ -251,7 +251,7 @@
 		<amp-story-page id="al-ankabut-8">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-bottom">
+					<div class="panel" animate-in="drop" animate-in-duration="0.9s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="46" class="quote">"Dan Kami wajibkan kepada manusia (berbuat) kebaikan kepada kedua orang tuanya."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/29/8/" target="_blank" rel="noopener">Baca QS. Al-Ankabut: 8 ↗</a>
 					</div>
@@ -262,7 +262,7 @@
 		<amp-story-page id="an-nisa-36">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-top">
+					<div class="panel" animate-in="fly-in-bottom" animate-in-duration="0.9s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="28" class="quote">"Dan sembahlah Allah dan janganlah kamu mempersekutukan-Nya dengan sesuatu apa pun. Dan berbuat baiklah kepada kedua orang tua, karib kerabat, anak-anak yatim, dan orang-orang miskin."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/4/36/" target="_blank" rel="noopener">Baca QS. An-Nisa: 36 ↗</a>
 					</div>

--- a/src/tentang-berbakti-kepada-orang-tua/index.html
+++ b/src/tentang-berbakti-kepada-orang-tua/index.html
@@ -20,6 +20,9 @@
 
 	<link rel='icon' type='image/png' href='https://www.baca-quran.id/icon-32.png'>
 	<link rel="canonical" href="https://www.baca-quran.id/stories/tentang-berbakti-kepada-orang-tua/">
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+	<link href="https://fonts.googleapis.com/css2?family=Courgette&family=Sacramento&display=swap" rel="stylesheet">
 
 	<style amp-boilerplate>
 		body {
@@ -132,7 +135,9 @@
 			flex: 1 1 auto;
 			min-height: 0;
 			text-align: center;
-			line-height: 1.5;
+			line-height: 1.6;
+			font-family: 'Courgette', cursive;
+			font-weight: 400;
 		}
 
 		.ref {
@@ -154,9 +159,10 @@
 		}
 
 		.cover-title {
-			font-size: 2.3rem;
-			line-height: 1.2;
-			font-weight: 700;
+			font-family: 'Sacramento', cursive;
+			font-size: 2.6rem;
+			line-height: 1.25;
+			font-weight: 400;
 			margin: 0;
 		}
 

--- a/src/tentang-ikhlas/index.html
+++ b/src/tentang-ikhlas/index.html
@@ -203,10 +203,10 @@
 		<amp-story-page id="cover">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel cover" animate-in="fade-in">
-						<p class="kicker">Web Stories</p>
-						<h1 class="cover-title">Tentang Ikhlas</h1>
-						<p class="cover-sub">Kumpulan ayat Al-Quran tentang ketulusan beribadah karena Allah</p>
+					<div class="panel cover">
+						<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Web Stories</p>
+						<h1 class="cover-title" animate-in="twirl-in" animate-in-duration="1s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Ikhlas</h1>
+						<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Kumpulan ayat Al-Quran tentang ketulusan beribadah karena Allah</p>
 					</div>
 				</div>
 			</amp-story-grid-layer>
@@ -218,7 +218,7 @@
 		<amp-story-page id="al-bayyinah-5">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-top">
+					<div class="panel" animate-in="rotate-in-left" animate-in-duration="1s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="28" class="quote">"Padahal mereka hanya diperintah menyembah Allah dengan ikhlas menaati-Nya semata-mata karena (menjalankan) agama, dan juga agar melaksanakan salat dan menunaikan zakat; dan yang demikian itulah agama yang lurus."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/98/5/" target="_blank" rel="noopener">Baca QS. Al-Bayyinah: 5 ↗</a>
 					</div>
@@ -229,7 +229,7 @@
 		<amp-story-page id="az-zumar-2">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-bottom">
+					<div class="panel" animate-in="rotate-in-right" animate-in-duration="1s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Sesungguhnya Kami menurunkan Kitab (Al-Qur'an) kepadamu dengan (membawa) kebenaran. Maka sembahlah Allah dengan tulus ikhlas beragama kepada-Nya."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/39/2/" target="_blank" rel="noopener">Baca QS. Az-Zumar: 2 ↗</a>
 					</div>
@@ -240,7 +240,7 @@
 		<amp-story-page id="al-anam-162">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-top">
+					<div class="panel" animate-in="rotate-in-left" animate-in-duration="1s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Katakanlah (Muhammad), 'Sesungguhnya salatku, ibadahku, hidupku dan matiku hanyalah untuk Allah, Tuhan seluruh alam.'"</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/6/162/" target="_blank" rel="noopener">Baca QS. Al-An'am: 162 ↗</a>
 					</div>
@@ -251,7 +251,7 @@
 		<amp-story-page id="az-zumar-11">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-bottom">
+					<div class="panel" animate-in="rotate-in-right" animate-in-duration="1s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Katakanlah, 'Sesungguhnya aku diperintahkan menyembah Allah dengan tulus ikhlas beragama kepada-Nya.'"</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/39/11/" target="_blank" rel="noopener">Baca QS. Az-Zumar: 11 ↗</a>
 					</div>
@@ -262,7 +262,7 @@
 		<amp-story-page id="al-kahf-110">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-top">
+					<div class="panel" animate-in="rotate-in-left" animate-in-duration="1s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Maka barangsiapa mengharap pertemuan dengan Tuhannya, hendaklah dia mengerjakan kebajikan dan janganlah dia mempersekutukan dengan sesuatu pun dalam beribadah kepada Tuhannya."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/18/110/" target="_blank" rel="noopener">Baca QS. Al-Kahf: 110 ↗</a>
 					</div>

--- a/src/tentang-ikhlas/index.html
+++ b/src/tentang-ikhlas/index.html
@@ -20,6 +20,9 @@
 
 	<link rel='icon' type='image/png' href='https://www.baca-quran.id/icon-32.png'>
 	<link rel="canonical" href="https://www.baca-quran.id/stories/tentang-ikhlas/">
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+	<link href="https://fonts.googleapis.com/css2?family=Courgette&family=Great+Vibes&display=swap" rel="stylesheet">
 
 	<style amp-boilerplate>
 		body {
@@ -132,7 +135,9 @@
 			flex: 1 1 auto;
 			min-height: 0;
 			text-align: center;
-			line-height: 1.5;
+			line-height: 1.6;
+			font-family: 'Courgette', cursive;
+			font-weight: 400;
 		}
 
 		.ref {
@@ -154,9 +159,10 @@
 		}
 
 		.cover-title {
-			font-size: 2.3rem;
-			line-height: 1.2;
-			font-weight: 700;
+			font-family: 'Great Vibes', cursive;
+			font-size: 2.6rem;
+			line-height: 1.25;
+			font-weight: 400;
 			margin: 0;
 		}
 

--- a/src/tentang-jujur/index.html
+++ b/src/tentang-jujur/index.html
@@ -203,10 +203,10 @@
 		<amp-story-page id="cover">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel cover" animate-in="fade-in">
-						<p class="kicker">Web Stories</p>
-						<h1 class="cover-title">Tentang Jujur</h1>
-						<p class="cover-sub">Kumpulan ayat Al-Quran tentang kebenaran dan kejujuran</p>
+					<div class="panel cover">
+						<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Web Stories</p>
+						<h1 class="cover-title" animate-in="whoosh-in-right" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Jujur</h1>
+						<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Kumpulan ayat Al-Quran tentang kebenaran dan kejujuran</p>
 					</div>
 				</div>
 			</amp-story-grid-layer>
@@ -218,7 +218,7 @@
 		<amp-story-page id="at-taubah-119">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-top">
+					<div class="panel" animate-in="whoosh-in-left" animate-in-duration="0.6s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Wahai orang-orang yang beriman! Bertakwalah kepada Allah, dan bersamalah kamu dengan orang-orang yang benar."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/9/119/" target="_blank" rel="noopener">Baca QS. At-Taubah: 119 ↗</a>
 					</div>
@@ -229,7 +229,7 @@
 		<amp-story-page id="al-ahzab-70">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-bottom">
+					<div class="panel" animate-in="whoosh-in-right" animate-in-duration="0.6s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Wahai orang-orang yang beriman! Bertakwalah kamu kepada Allah dan ucapkanlah perkataan yang benar,"</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/33/70/" target="_blank" rel="noopener">Baca QS. Al-Ahzab: 70 ↗</a>
 					</div>
@@ -240,7 +240,7 @@
 		<amp-story-page id="al-ahzab-71">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-top">
+					<div class="panel" animate-in="whoosh-in-left" animate-in-duration="0.6s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"niscaya Allah akan memperbaiki amal-amalmu dan mengampuni dosa-dosamu. Dan barangsiapa menaati Allah dan Rasul-Nya, maka sungguh, dia menang dengan kemenangan yang agung."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/33/71/" target="_blank" rel="noopener">Baca QS. Al-Ahzab: 71 ↗</a>
 					</div>
@@ -251,7 +251,7 @@
 		<amp-story-page id="az-zumar-33">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-bottom">
+					<div class="panel" animate-in="whoosh-in-right" animate-in-duration="0.6s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan orang yang membawa kebenaran (Muhammad) dan orang yang membenarkannya, mereka itulah orang yang bertakwa."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/39/33/" target="_blank" rel="noopener">Baca QS. Az-Zumar: 33 ↗</a>
 					</div>
@@ -262,7 +262,7 @@
 		<amp-story-page id="al-maidah-119">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-top">
+					<div class="panel" animate-in="whoosh-in-left" animate-in-duration="0.6s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Inilah saat orang yang benar memperoleh manfaat dari kebenarannya. Mereka memperoleh surga yang mengalir di bawahnya sungai-sungai, mereka kekal di dalamnya selama-lamanya."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/5/119/" target="_blank" rel="noopener">Baca QS. Al-Ma'idah: 119 ↗</a>
 					</div>

--- a/src/tentang-jujur/index.html
+++ b/src/tentang-jujur/index.html
@@ -20,6 +20,9 @@
 
 	<link rel='icon' type='image/png' href='https://www.baca-quran.id/icon-32.png'>
 	<link rel="canonical" href="https://www.baca-quran.id/stories/tentang-jujur/">
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+	<link href="https://fonts.googleapis.com/css2?family=Caveat:wght@500;600;700&family=Kaushan+Script&display=swap" rel="stylesheet">
 
 	<style amp-boilerplate>
 		body {
@@ -132,7 +135,9 @@
 			flex: 1 1 auto;
 			min-height: 0;
 			text-align: center;
-			line-height: 1.5;
+			line-height: 1.6;
+			font-family: 'Caveat', cursive;
+			font-weight: 600;
 		}
 
 		.ref {
@@ -154,9 +159,10 @@
 		}
 
 		.cover-title {
-			font-size: 2.3rem;
-			line-height: 1.2;
-			font-weight: 700;
+			font-family: 'Kaushan Script', cursive;
+			font-size: 2.6rem;
+			line-height: 1.25;
+			font-weight: 400;
 			margin: 0;
 		}
 

--- a/src/tentang-silaturahmi/index.html
+++ b/src/tentang-silaturahmi/index.html
@@ -20,6 +20,9 @@
 
 	<link rel='icon' type='image/png' href='https://www.baca-quran.id/icon-32.png'>
 	<link rel="canonical" href="https://www.baca-quran.id/stories/tentang-silaturahmi/">
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+	<link href="https://fonts.googleapis.com/css2?family=Merienda:wght@500;600;700&family=Lobster&display=swap" rel="stylesheet">
 
 	<style amp-boilerplate>
 		body {
@@ -132,7 +135,9 @@
 			flex: 1 1 auto;
 			min-height: 0;
 			text-align: center;
-			line-height: 1.5;
+			line-height: 1.6;
+			font-family: 'Merienda', cursive;
+			font-weight: 600;
 		}
 
 		.ref {
@@ -154,9 +159,10 @@
 		}
 
 		.cover-title {
-			font-size: 2.3rem;
-			line-height: 1.2;
-			font-weight: 700;
+			font-family: 'Lobster', cursive;
+			font-size: 2.6rem;
+			line-height: 1.25;
+			font-weight: 400;
 			margin: 0;
 		}
 

--- a/src/tentang-silaturahmi/index.html
+++ b/src/tentang-silaturahmi/index.html
@@ -203,10 +203,10 @@
 		<amp-story-page id="cover">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel cover" animate-in="fade-in">
-						<p class="kicker">Web Stories</p>
-						<h1 class="cover-title">Tentang Silaturahmi</h1>
-						<p class="cover-sub">Kumpulan ayat Al-Quran tentang menyambung hubungan kekeluargaan</p>
+					<div class="panel cover">
+						<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Web Stories</p>
+						<h1 class="cover-title" animate-in="fly-in-left" animate-in-duration="0.9s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Silaturahmi</h1>
+						<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Kumpulan ayat Al-Quran tentang menyambung hubungan kekeluargaan</p>
 					</div>
 				</div>
 			</amp-story-grid-layer>
@@ -218,7 +218,7 @@
 		<amp-story-page id="an-nisa-1">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-top">
+					<div class="panel" animate-in="fly-in-left" animate-in-duration="0.9s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan bertakwalah kepada Allah yang dengan nama-Nya kamu saling meminta, dan (peliharalah) hubungan kekeluargaan. Sesungguhnya Allah selalu menjaga dan mengawasimu."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/4/1/" target="_blank" rel="noopener">Baca QS. An-Nisa: 1 ↗</a>
 					</div>
@@ -229,7 +229,7 @@
 		<amp-story-page id="ar-rad-21">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-bottom">
+					<div class="panel" animate-in="fly-in-right" animate-in-duration="0.9s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan orang-orang yang menghubungkan apa yang diperintahkan Allah agar dihubungkan, dan mereka takut kepada Tuhannya dan takut kepada hisab yang buruk."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/13/21/" target="_blank" rel="noopener">Baca QS. Ar-Ra'd: 21 ↗</a>
 					</div>
@@ -240,7 +240,7 @@
 		<amp-story-page id="an-nahl-90">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-top">
+					<div class="panel" animate-in="fly-in-left" animate-in-duration="0.9s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Sesungguhnya Allah menyuruh (kamu) berlaku adil dan berbuat kebajikan, memberi bantuan kepada kerabat, dan Dia melarang (melakukan) perbuatan keji, kemungkaran, dan permusuhan."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/16/90/" target="_blank" rel="noopener">Baca QS. An-Nahl: 90 ↗</a>
 					</div>
@@ -251,7 +251,7 @@
 		<amp-story-page id="muhammad-22">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-bottom">
+					<div class="panel" animate-in="fly-in-right" animate-in-duration="0.9s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Maka apakah sekiranya kamu berkuasa, kamu akan berbuat kerusakan di bumi dan memutuskan hubungan kekeluargaan?"</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/47/22/" target="_blank" rel="noopener">Baca QS. Muhammad: 22 ↗</a>
 					</div>
@@ -262,7 +262,7 @@
 		<amp-story-page id="al-isra-26">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-top">
+					<div class="panel" animate-in="fly-in-left" animate-in-duration="0.9s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan berikanlah haknya kepada kerabat dekat, juga kepada orang miskin dan orang yang dalam perjalanan; dan janganlah kamu menghambur-hamburkan (hartamu) secara boros."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/17/26/" target="_blank" rel="noopener">Baca QS. Al-Isra: 26 ↗</a>
 					</div>

--- a/src/tentang-syukur/index.html
+++ b/src/tentang-syukur/index.html
@@ -203,10 +203,10 @@
 		<amp-story-page id="cover">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel cover" animate-in="fade-in">
-						<p class="kicker">Web Stories</p>
-						<h1 class="cover-title">Tentang Syukur</h1>
-						<p class="cover-sub">Kumpulan ayat Al-Quran tentang bersyukur atas nikmat Allah</p>
+					<div class="panel cover">
+						<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Web Stories</p>
+						<h1 class="cover-title" animate-in="zoom-in" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Syukur</h1>
+						<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Kumpulan ayat Al-Quran tentang bersyukur atas nikmat Allah</p>
 					</div>
 				</div>
 			</amp-story-grid-layer>
@@ -218,7 +218,7 @@
 		<amp-story-page id="ibrahim-7">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-top">
+					<div class="panel" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Sesungguhnya jika kamu bersyukur, niscaya Aku akan menambah (nikmat) kepadamu, tetapi jika kamu mengingkari (nikmat-Ku), maka sesungguhnya azab-Ku sangat pedih."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/14/7/" target="_blank" rel="noopener">Baca QS. Ibrahim: 7 ↗</a>
 					</div>
@@ -229,7 +229,7 @@
 		<amp-story-page id="al-baqarah-152">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-bottom">
+					<div class="panel" animate-in="zoom-in" animate-in-duration="0.8s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Maka ingatlah kepada-Ku, Aku pun akan ingat kepadamu. Bersyukurlah kepada-Ku, dan janganlah kamu ingkar kepada-Ku."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/2/152/" target="_blank" rel="noopener">Baca QS. Al-Baqarah: 152 ↗</a>
 					</div>
@@ -240,7 +240,7 @@
 		<amp-story-page id="an-nahl-18">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-top">
+					<div class="panel" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan jika kamu menghitung nikmat Allah, niscaya kamu tidak akan mampu menghitungnya. Sungguh, Allah benar-benar Maha Pengampun, Maha Penyayang."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/16/18/" target="_blank" rel="noopener">Baca QS. An-Nahl: 18 ↗</a>
 					</div>
@@ -251,7 +251,7 @@
 		<amp-story-page id="luqman-12">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-bottom">
+					<div class="panel" animate-in="zoom-in" animate-in-duration="0.8s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Barangsiapa bersyukur (kepada Allah), maka sesungguhnya dia bersyukur untuk dirinya sendiri; dan barangsiapa tidak bersyukur, maka sesungguhnya Allah Mahakaya, Maha Terpuji."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/31/12/" target="_blank" rel="noopener">Baca QS. Luqman: 12 ↗</a>
 					</div>
@@ -262,7 +262,7 @@
 		<amp-story-page id="az-zumar-7">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-top">
+					<div class="panel" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan Dia tidak meridai kekafiran bagi hamba-Nya. Jika kamu bersyukur, Dia meridai kesyukuranmu itu."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/39/7/" target="_blank" rel="noopener">Baca QS. Az-Zumar: 7 ↗</a>
 					</div>

--- a/src/tentang-syukur/index.html
+++ b/src/tentang-syukur/index.html
@@ -20,6 +20,9 @@
 
 	<link rel='icon' type='image/png' href='https://www.baca-quran.id/icon-32.png'>
 	<link rel="canonical" href="https://www.baca-quran.id/stories/tentang-syukur/">
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+	<link href="https://fonts.googleapis.com/css2?family=Merienda:wght@500;600;700&family=Pacifico&display=swap" rel="stylesheet">
 
 	<style amp-boilerplate>
 		body {
@@ -132,7 +135,9 @@
 			flex: 1 1 auto;
 			min-height: 0;
 			text-align: center;
-			line-height: 1.5;
+			line-height: 1.6;
+			font-family: 'Merienda', cursive;
+			font-weight: 600;
 		}
 
 		.ref {
@@ -154,9 +159,10 @@
 		}
 
 		.cover-title {
-			font-size: 2.3rem;
-			line-height: 1.2;
-			font-weight: 700;
+			font-family: 'Pacifico', cursive;
+			font-size: 2.6rem;
+			line-height: 1.25;
+			font-weight: 400;
 			margin: 0;
 		}
 

--- a/src/tentang-taubat/index.html
+++ b/src/tentang-taubat/index.html
@@ -203,10 +203,10 @@
 		<amp-story-page id="cover">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel cover" animate-in="fade-in">
-						<p class="kicker">Web Stories</p>
-						<h1 class="cover-title">Tentang Taubat</h1>
-						<p class="cover-sub">Kumpulan ayat Al-Quran tentang kembali memohon ampun kepada Allah</p>
+					<div class="panel cover">
+						<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-in-out" animate-in-delay="0.15s">Web Stories</p>
+						<h1 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="1s" animate-in-timing-function="ease-in-out" animate-in-delay="0.4s">Tentang Taubat</h1>
+						<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-in-out" animate-in-delay="0.85s">Kumpulan ayat Al-Quran tentang kembali memohon ampun kepada Allah</p>
 					</div>
 				</div>
 			</amp-story-grid-layer>
@@ -218,7 +218,7 @@
 		<amp-story-page id="az-zumar-53">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-top">
+					<div class="panel" animate-in="fly-in-bottom" animate-in-duration="1s" animate-in-timing-function="ease-in-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="28" class="quote">"Wahai hamba-hamba-Ku yang melampaui batas terhadap diri mereka sendiri! Janganlah kamu berputus asa dari rahmat Allah. Sesungguhnya Allah mengampuni dosa-dosa semuanya. Sungguh, Dialah Yang Maha Pengampun, Maha Penyayang."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/39/53/" target="_blank" rel="noopener">Baca QS. Az-Zumar: 53 ↗</a>
 					</div>
@@ -229,7 +229,7 @@
 		<amp-story-page id="at-tahrim-8">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-bottom">
+					<div class="panel" animate-in="fade-in" animate-in-duration="1s" animate-in-timing-function="ease-in-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Wahai orang-orang yang beriman! Bertobatlah kepada Allah dengan tobat yang semurni-murninya, mudah-mudahan Tuhanmu akan menghapus kesalahan-kesalahanmu."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/66/8/" target="_blank" rel="noopener">Baca QS. At-Tahrim: 8 ↗</a>
 					</div>
@@ -240,7 +240,7 @@
 		<amp-story-page id="an-nur-31">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-top">
+					<div class="panel" animate-in="fly-in-bottom" animate-in-duration="1s" animate-in-timing-function="ease-in-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan bertobatlah kamu semua kepada Allah, wahai orang-orang yang beriman, agar kamu beruntung."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/24/31/" target="_blank" rel="noopener">Baca QS. An-Nur: 31 ↗</a>
 					</div>
@@ -251,7 +251,7 @@
 		<amp-story-page id="al-baqarah-222">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-bottom">
+					<div class="panel" animate-in="fade-in" animate-in-duration="1s" animate-in-timing-function="ease-in-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="46" class="quote">"Sungguh, Allah menyukai orang yang bertobat dan menyukai orang yang menyucikan diri."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/2/222/" target="_blank" rel="noopener">Baca QS. Al-Baqarah: 222 ↗</a>
 					</div>
@@ -262,7 +262,7 @@
 		<amp-story-page id="hud-3">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-top">
+					<div class="panel" animate-in="fly-in-bottom" animate-in-duration="1s" animate-in-timing-function="ease-in-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan hendaklah kamu memohon ampun kepada Tuhanmu dan bertobat kepada-Nya, niscaya Dia akan memberi kenikmatan yang baik kepadamu sampai waktu yang telah ditentukan."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/11/3/" target="_blank" rel="noopener">Baca QS. Hud: 3 ↗</a>
 					</div>

--- a/src/tentang-taubat/index.html
+++ b/src/tentang-taubat/index.html
@@ -20,6 +20,9 @@
 
 	<link rel='icon' type='image/png' href='https://www.baca-quran.id/icon-32.png'>
 	<link rel="canonical" href="https://www.baca-quran.id/stories/tentang-taubat/">
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+	<link href="https://fonts.googleapis.com/css2?family=Kalam:wght@400;700&family=Parisienne&display=swap" rel="stylesheet">
 
 	<style amp-boilerplate>
 		body {
@@ -132,7 +135,9 @@
 			flex: 1 1 auto;
 			min-height: 0;
 			text-align: center;
-			line-height: 1.5;
+			line-height: 1.6;
+			font-family: 'Kalam', cursive;
+			font-weight: 400;
 		}
 
 		.ref {
@@ -154,9 +159,10 @@
 		}
 
 		.cover-title {
-			font-size: 2.3rem;
-			line-height: 1.2;
-			font-weight: 700;
+			font-family: 'Parisienne', cursive;
+			font-size: 2.6rem;
+			line-height: 1.25;
+			font-weight: 400;
 			margin: 0;
 		}
 

--- a/src/tentang-tawakal/index.html
+++ b/src/tentang-tawakal/index.html
@@ -203,10 +203,10 @@
 		<amp-story-page id="cover">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel cover" animate-in="fade-in">
-						<p class="kicker">Web Stories</p>
-						<h1 class="cover-title">Tentang Tawakal</h1>
-						<p class="cover-sub">Kumpulan ayat Al-Quran tentang berserah diri kepada Allah</p>
+					<div class="panel cover">
+						<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-in-out" animate-in-delay="0.15s">Web Stories</p>
+						<h1 class="cover-title" animate-in="fade-in" animate-in-duration="1.2s" animate-in-timing-function="ease-in-out" animate-in-delay="0.4s">Tentang Tawakal</h1>
+						<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-in-out" animate-in-delay="0.85s">Kumpulan ayat Al-Quran tentang berserah diri kepada Allah</p>
 					</div>
 				</div>
 			</amp-story-grid-layer>
@@ -218,7 +218,7 @@
 		<amp-story-page id="at-talaq-3">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-top">
+					<div class="panel" animate-in="pan-up" animate-in-duration="1.2s" animate-in-timing-function="ease-in-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan barangsiapa bertawakal kepada Allah, niscaya Allah akan mencukupkan (keperluan)nya. Sesungguhnya Allah melaksanakan urusan-Nya."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/65/3/" target="_blank" rel="noopener">Baca QS. At-Talaq: 3 ↗</a>
 					</div>
@@ -229,7 +229,7 @@
 		<amp-story-page id="ali-imran-159">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-bottom">
+					<div class="panel" animate-in="fade-in" animate-in-duration="1.2s" animate-in-timing-function="ease-in-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Kemudian, apabila engkau telah membulatkan tekad, maka bertawakallah kepada Allah. Sungguh, Allah mencintai orang yang bertawakal."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/3/159/" target="_blank" rel="noopener">Baca QS. Ali 'Imran: 159 ↗</a>
 					</div>
@@ -240,7 +240,7 @@
 		<amp-story-page id="al-anfal-2">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-top">
+					<div class="panel" animate-in="pan-up" animate-in-duration="1.2s" animate-in-timing-function="ease-in-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="28" class="quote">"Sesungguhnya orang-orang yang beriman adalah mereka yang apabila disebut nama Allah gemetar hatinya, dan apabila dibacakan ayat-ayat-Nya bertambah (kuat) imannya, dan hanya kepada Tuhan mereka bertawakal."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/8/2/" target="_blank" rel="noopener">Baca QS. Al-Anfal: 2 ↗</a>
 					</div>
@@ -251,7 +251,7 @@
 		<amp-story-page id="al-maidah-23">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-bottom">
+					<div class="panel" animate-in="fade-in" animate-in-duration="1.2s" animate-in-timing-function="ease-in-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="46" class="quote">"Dan bertawakallah kamu hanya kepada Allah, jika kamu orang-orang beriman."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/5/23/" target="_blank" rel="noopener">Baca QS. Al-Ma'idah: 23 ↗</a>
 					</div>
@@ -262,7 +262,7 @@
 		<amp-story-page id="hud-88">
 			<amp-story-grid-layer template="fill">
 				<div class="page">
-					<div class="panel" animate-in="fly-in-top">
+					<div class="panel" animate-in="pan-up" animate-in-duration="1.2s" animate-in-timing-function="ease-in-out">
 						<amp-fit-text layout="flex-item" min-font-size="14" max-font-size="36" class="quote">"Dan tidak ada (manfaat) taufik bagiku melainkan dengan (pertolongan) Allah. Hanya kepada-Nya aku bertawakal dan hanya kepada-Nya aku kembali."</amp-fit-text>
 						<a class="ref" href="https://www.baca-quran.id/surah/11/88/" target="_blank" rel="noopener">Baca QS. Hud: 88 ↗</a>
 					</div>

--- a/src/tentang-tawakal/index.html
+++ b/src/tentang-tawakal/index.html
@@ -20,6 +20,9 @@
 
 	<link rel='icon' type='image/png' href='https://www.baca-quran.id/icon-32.png'>
 	<link rel="canonical" href="https://www.baca-quran.id/stories/tentang-tawakal/">
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+	<link href="https://fonts.googleapis.com/css2?family=Caveat:wght@500;600;700&family=Satisfy&display=swap" rel="stylesheet">
 
 	<style amp-boilerplate>
 		body {
@@ -132,7 +135,9 @@
 			flex: 1 1 auto;
 			min-height: 0;
 			text-align: center;
-			line-height: 1.5;
+			line-height: 1.6;
+			font-family: 'Caveat', cursive;
+			font-weight: 600;
 		}
 
 		.ref {
@@ -154,9 +159,10 @@
 		}
 
 		.cover-title {
-			font-size: 2.3rem;
-			line-height: 1.2;
-			font-weight: 700;
+			font-family: 'Satisfy', cursive;
+			font-size: 2.6rem;
+			line-height: 1.25;
+			font-weight: 400;
 			margin: 0;
 		}
 


### PR DESCRIPTION
The 7 gradient web stories shipped with a plain 'Merriweather' serif that
wasn't even loaded, so they fell back to the system font and lost the
cursive look the original 2020 stories had (Pacifico + Merienda One).

Bring cursive back as the default for verse content, and give each theme
its own pairing: a decorative script for the cover title plus a readable
handwriting/script face for the verse body (verses stay legible on the
dark scrim). Each page loads only its own fonts via an AMP-valid Google
Fonts <link>:

- syukur      Pacifico / Merienda   (the classic default)
- tawakal     Satisfy / Caveat
- ikhlas      Great Vibes / Courgette
- taubat      Parisienne / Kalam
- jujur       Kaushan Script / Caveat
- berbakti    Sacramento / Courgette
- silaturahmi Lobster / Merienda

All 10 stories still pass amphtml-validator.

https://claude.ai/code/session_01DccNn3iEj3mdV9ekY6XXCD