### PR TITLE
Match landing page footer with baca-quran.id and add /tulisan link

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -896,7 +896,6 @@
 				<h4>Tautan</h4>
 				<ul>
 					<li><a href="https://www.baca-quran.id/" target="_blank" rel="noopener noreferrer">Baca-Quran.id</a></li>
-					<li><a href="https://www.baca-quran.id/stories/" target="_blank" rel="noopener noreferrer">Web Stories</a></li>
 					<li><a href="https://www.baca-quran.id/tulisan/" target="_blank" rel="noopener noreferrer">Tulisan</a></li>
 					<li><a href="https://tools.mazipan.space/" target="_blank" rel="noopener noreferrer">Web Tool Libraries</a></li>
 					<li><a href="https://mazipan.space/" target="_blank" rel="noopener noreferrer">Irfan Maulana</a></li>

--- a/src/index.html
+++ b/src/index.html
@@ -587,13 +587,29 @@
 			padding: 2.8rem 1.5rem 1.5rem;
 			display: grid;
 			gap: 2rem;
-			grid-template-columns: 1fr;
+			grid-template-columns: repeat(2, 1fr);
 		}
 
 		@media (min-width: 44rem) {
 			.footer-inner {
-				grid-template-columns: 2fr 1fr;
+				grid-template-columns: 1.6fr repeat(3, 1fr);
 				gap: 2.5rem;
+			}
+		}
+
+		@media (min-width: 60rem) {
+			.footer-inner {
+				grid-template-columns: 1.6fr repeat(4, 1fr);
+			}
+		}
+
+		.footer-brand {
+			grid-column: 1 / -1;
+		}
+
+		@media (min-width: 44rem) {
+			.footer-brand {
+				grid-column: auto;
 			}
 		}
 
@@ -891,6 +907,34 @@
 					<span>Web Stories</span>
 				</a>
 				<p>Cerita visual singkat dari ayat-ayat Al-Quran, dipersembahkan oleh Baca-Quran.id agar lebih dekat dengan firman-Nya, di mana saja.</p>
+			</div>
+			<div class="footer-col">
+				<h4>Al-Qur'an</h4>
+				<ul>
+					<li><a href="https://www.baca-quran.id/all-surah/" target="_blank" rel="noopener noreferrer">Semua Surah</a></li>
+					<li><a href="https://www.baca-quran.id/surah/1/1/" target="_blank" rel="noopener noreferrer">Baca Per Ayat</a></li>
+					<li><a href="https://www.baca-quran.id/juz-amma/" target="_blank" rel="noopener noreferrer">Juz Amma</a></li>
+					<li><a href="https://www.baca-quran.id/ayat-kursi/" target="_blank" rel="noopener noreferrer">Ayat Kursi</a></li>
+				</ul>
+			</div>
+			<div class="footer-col">
+				<h4>Doa &amp; Dzikir</h4>
+				<ul>
+					<li><a href="https://www.baca-quran.id/daily-doa/" target="_blank" rel="noopener noreferrer">Doa Harian</a></li>
+					<li><a href="https://www.baca-quran.id/wirid/" target="_blank" rel="noopener noreferrer">Wirid</a></li>
+					<li><a href="https://www.baca-quran.id/adhkar/" target="_blank" rel="noopener noreferrer">Dzikir Pagi &amp; Petang</a></li>
+					<li><a href="https://www.baca-quran.id/tasbih/" target="_blank" rel="noopener noreferrer">Tasbih</a></li>
+					<li><a href="https://www.baca-quran.id/tahlil/" target="_blank" rel="noopener noreferrer">Tahlil</a></li>
+				</ul>
+			</div>
+			<div class="footer-col">
+				<h4>Fitur Lainnya</h4>
+				<ul>
+					<li><a href="https://www.baca-quran.id/asmaul-husna/" target="_blank" rel="noopener noreferrer">Asmaul Husna</a></li>
+					<li><a href="https://www.baca-quran.id/jadwal-sholat/" target="_blank" rel="noopener noreferrer">Jadwal Sholat</a></li>
+					<li><a href="https://www.baca-quran.id/pencatat-ibadah/" target="_blank" rel="noopener noreferrer">Pencatat Ibadah</a></li>
+					<li><a href="https://www.baca-quran.id/kalender-hijriyah/" target="_blank" rel="noopener noreferrer">Kalender Hijriyah</a></li>
+				</ul>
 			</div>
 			<div class="footer-col">
 				<h4>Tautan</h4>

--- a/src/index.html
+++ b/src/index.html
@@ -592,7 +592,7 @@
 
 		@media (min-width: 44rem) {
 			.footer-inner {
-				grid-template-columns: 1.5fr 1fr 1fr;
+				grid-template-columns: 2fr 1fr;
 				gap: 2.5rem;
 			}
 		}
@@ -893,18 +893,13 @@
 				<p>Cerita visual singkat dari ayat-ayat Al-Quran, dipersembahkan oleh Baca-Quran.id agar lebih dekat dengan firman-Nya, di mana saja.</p>
 			</div>
 			<div class="footer-col">
-				<h4>Jelajahi</h4>
+				<h4>Tautan</h4>
 				<ul>
-					<li><a href="/stories/">Semua Cerita</a></li>
 					<li><a href="https://www.baca-quran.id/" target="_blank" rel="noopener noreferrer">Baca-Quran.id</a></li>
-					<li><a href="https://www.baca-quran.id/tulisan/" target="_blank" rel="noopener noreferrer">Web Blog</a></li>
-				</ul>
-			</div>
-			<div class="footer-col">
-				<h4>Lainnya</h4>
-				<ul>
+					<li><a href="https://www.baca-quran.id/stories/" target="_blank" rel="noopener noreferrer">Web Stories</a></li>
+					<li><a href="https://www.baca-quran.id/tulisan/" target="_blank" rel="noopener noreferrer">Tulisan</a></li>
+					<li><a href="https://tools.mazipan.space/" target="_blank" rel="noopener noreferrer">Web Tool Libraries</a></li>
 					<li><a href="https://mazipan.space/" target="_blank" rel="noopener noreferrer">Irfan Maulana</a></li>
-					<li><a href="https://tools.mazipa.space" target="_blank" rel="noopener noreferrer">Web Tool Libraries</a></li>
 				</ul>
 			</div>
 		</div>


### PR DESCRIPTION
## Summary

Updates the landing page (`src/index.html`) footer to mirror the footer on [www.baca-quran.id/tulisan](https://www.baca-quran.id/tulisan/), and adds a link to `/tulisan`.

## Changes

- Replaced the previous two-column footer ("Jelajahi" / "Lainnya") with four link groups matching the reference site:
  - **Al-Qur'an** — Semua Surah, Baca Per Ayat, Juz Amma, Ayat Kursi
  - **Doa & Dzikir** — Doa Harian, Wirid, Dzikir Pagi & Petang, Tasbih, Tahlil
  - **Fitur Lainnya** — Asmaul Husna, Jadwal Sholat, Pencatat Ibadah, Kalender Hijriyah
  - **Tautan** — Baca-Quran.id, Tulisan, Web Tool Libraries, Irfan Maulana
- Added the **Tulisan** (`/tulisan`) link in the Tautan group.
- Removed the redundant self-link to Web Stories (this page is Web Stories).
- Fixed a pre-existing typo in the tools URL (`tools.mazipa.space` → `tools.mazipan.space`).
- Made the footer grid responsive: 2 columns on mobile (brand full-width), brand + 3 columns on tablet, brand + 4 columns on desktop.

## Notes

`src/index.html` is hand-maintained — the `generate:index` script only syncs story cards, so the footer edits are safe from being overwritten by the build.

https://claude.ai/code/session_01VHKwLhzyv21hvLFNtrYdaP