### PR TITLE
fix: end-of-story link not clickable due to AMP animation wrappers

### DIFF
--- a/src/tentang-berbakti-kepada-orang-tua/index.html
+++ b/src/tentang-berbakti-kepada-orang-tua/index.html
@@ -291,17 +291,18 @@
 		</amp-story-page>
 
 		<amp-story-page id="next-story">
-			<amp-story-grid-layer template="fill">
-				<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-silaturahmi/" target="_blank" rel="noopener">
-					<div class="page">
+		<amp-story-grid-layer template="fill">
+			<div class="page">
 						<div class="panel cover">
 							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
 							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Silaturahmi</h2>
 							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
 						</div>
 					</div>
-				</a>
-			</amp-story-grid-layer>
+		</amp-story-grid-layer>
+		<amp-story-grid-layer template="fill">
+			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-silaturahmi/" target="_blank" rel="noopener"></a>
+		</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-analytics type="gtag" data-credentials="include">

--- a/src/tentang-ikhlas/index.html
+++ b/src/tentang-ikhlas/index.html
@@ -291,17 +291,18 @@
 		</amp-story-page>
 
 		<amp-story-page id="next-story">
-			<amp-story-grid-layer template="fill">
-				<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-taubat/" target="_blank" rel="noopener">
-					<div class="page">
+		<amp-story-grid-layer template="fill">
+			<div class="page">
 						<div class="panel cover">
 							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
 							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Taubat</h2>
 							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
 						</div>
 					</div>
-				</a>
-			</amp-story-grid-layer>
+		</amp-story-grid-layer>
+		<amp-story-grid-layer template="fill">
+			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-taubat/" target="_blank" rel="noopener"></a>
+		</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-analytics type="gtag" data-credentials="include">

--- a/src/tentang-jujur/index.html
+++ b/src/tentang-jujur/index.html
@@ -291,17 +291,18 @@
 		</amp-story-page>
 
 		<amp-story-page id="next-story">
-			<amp-story-grid-layer template="fill">
-				<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-berbakti-kepada-orang-tua/" target="_blank" rel="noopener">
-					<div class="page">
+		<amp-story-grid-layer template="fill">
+			<div class="page">
 						<div class="panel cover">
 							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
 							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Berbakti kepada Orang Tua</h2>
 							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
 						</div>
 					</div>
-				</a>
-			</amp-story-grid-layer>
+		</amp-story-grid-layer>
+		<amp-story-grid-layer template="fill">
+			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-berbakti-kepada-orang-tua/" target="_blank" rel="noopener"></a>
+		</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-analytics type="gtag" data-credentials="include">

--- a/src/tentang-menuntut-ilmu/index.html
+++ b/src/tentang-menuntut-ilmu/index.html
@@ -301,17 +301,18 @@
 
 
 		<amp-story-page id="next-story">
-			<amp-story-grid-layer template="fill">
-				<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-sedekah/" target="_blank" rel="noopener">
-					<div class="ns-page">
+		<amp-story-grid-layer template="fill">
+			<div class="ns-page">
 						<div class="ns-panel">
 							<p class="ns-kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
 							<h2 class="ns-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Sedekah</h2>
 							<p class="ns-hint" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
 						</div>
 					</div>
-				</a>
-			</amp-story-grid-layer>
+		</amp-story-grid-layer>
+		<amp-story-grid-layer template="fill">
+			<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-sedekah/" target="_blank" rel="noopener"></a>
+		</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-analytics type="gtag" data-credentials="include">

--- a/src/tentang-sabar/index.html
+++ b/src/tentang-sabar/index.html
@@ -240,17 +240,18 @@
 		</amp-story-page>
 
 		<amp-story-page id="next-story">
-			<amp-story-grid-layer template="fill">
-				<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-syukur/" target="_blank" rel="noopener">
-					<div class="ns-page">
+		<amp-story-grid-layer template="fill">
+			<div class="ns-page">
 						<div class="ns-panel">
 							<p class="ns-kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
 							<h2 class="ns-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Syukur</h2>
 							<p class="ns-hint" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
 						</div>
 					</div>
-				</a>
-			</amp-story-grid-layer>
+		</amp-story-grid-layer>
+		<amp-story-grid-layer template="fill">
+			<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-syukur/" target="_blank" rel="noopener"></a>
+		</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-analytics type="gtag" data-credentials="include">

--- a/src/tentang-sedekah/index.html
+++ b/src/tentang-sedekah/index.html
@@ -318,17 +318,18 @@
 		</amp-story-page>
 
 		<amp-story-page id="next-story">
-			<amp-story-grid-layer template="fill">
-				<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-sabar/" target="_blank" rel="noopener">
-					<div class="ns-page">
+		<amp-story-grid-layer template="fill">
+			<div class="ns-page">
 						<div class="ns-panel">
 							<p class="ns-kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
 							<h2 class="ns-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Sabar</h2>
 							<p class="ns-hint" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
 						</div>
 					</div>
-				</a>
-			</amp-story-grid-layer>
+		</amp-story-grid-layer>
+		<amp-story-grid-layer template="fill">
+			<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-sabar/" target="_blank" rel="noopener"></a>
+		</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-analytics type="gtag" data-credentials="include">

--- a/src/tentang-silaturahmi/index.html
+++ b/src/tentang-silaturahmi/index.html
@@ -291,17 +291,18 @@
 		</amp-story-page>
 
 		<amp-story-page id="next-story">
-			<amp-story-grid-layer template="fill">
-				<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-menuntut-ilmu/" target="_blank" rel="noopener">
-					<div class="page">
+		<amp-story-grid-layer template="fill">
+			<div class="page">
 						<div class="panel cover">
 							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
 							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Menuntut Ilmu</h2>
 							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
 						</div>
 					</div>
-				</a>
-			</amp-story-grid-layer>
+		</amp-story-grid-layer>
+		<amp-story-grid-layer template="fill">
+			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-menuntut-ilmu/" target="_blank" rel="noopener"></a>
+		</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-analytics type="gtag" data-credentials="include">

--- a/src/tentang-syukur/index.html
+++ b/src/tentang-syukur/index.html
@@ -291,17 +291,18 @@
 		</amp-story-page>
 
 		<amp-story-page id="next-story">
-			<amp-story-grid-layer template="fill">
-				<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-tawakal/" target="_blank" rel="noopener">
-					<div class="page">
+		<amp-story-grid-layer template="fill">
+			<div class="page">
 						<div class="panel cover">
 							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
 							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Tawakal</h2>
 							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
 						</div>
 					</div>
-				</a>
-			</amp-story-grid-layer>
+		</amp-story-grid-layer>
+		<amp-story-grid-layer template="fill">
+			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-tawakal/" target="_blank" rel="noopener"></a>
+		</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-analytics type="gtag" data-credentials="include">

--- a/src/tentang-taubat/index.html
+++ b/src/tentang-taubat/index.html
@@ -291,17 +291,18 @@
 		</amp-story-page>
 
 		<amp-story-page id="next-story">
-			<amp-story-grid-layer template="fill">
-				<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-jujur/" target="_blank" rel="noopener">
-					<div class="page">
+		<amp-story-grid-layer template="fill">
+			<div class="page">
 						<div class="panel cover">
 							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
 							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Jujur</h2>
 							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
 						</div>
 					</div>
-				</a>
-			</amp-story-grid-layer>
+		</amp-story-grid-layer>
+		<amp-story-grid-layer template="fill">
+			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-jujur/" target="_blank" rel="noopener"></a>
+		</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-analytics type="gtag" data-credentials="include">

--- a/src/tentang-tawakal/index.html
+++ b/src/tentang-tawakal/index.html
@@ -291,17 +291,18 @@
 		</amp-story-page>
 
 		<amp-story-page id="next-story">
-			<amp-story-grid-layer template="fill">
-				<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-ikhlas/" target="_blank" rel="noopener">
-					<div class="page">
+		<amp-story-grid-layer template="fill">
+			<div class="page">
 						<div class="panel cover">
 							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
 							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Ikhlas</h2>
 							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
 						</div>
 					</div>
-				</a>
-			</amp-story-grid-layer>
+		</amp-story-grid-layer>
+		<amp-story-grid-layer template="fill">
+			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-ikhlas/" target="_blank" rel="noopener"></a>
+		</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-analytics type="gtag" data-credentials="include">


### PR DESCRIPTION
## Summary

- The "next story" link on the last page of each story was unclickable because AMP's animation wrappers (added for `animate-in` elements) rendered **on top of and outside** the `<a>` tag, intercepting all tap/click events
- AMP's left/right navigation tap zones also ate clicks on the edges of the screen on the last page
- Fix applied to all 10 stories

## What changed

Each `next-story` page was restructured from one grid layer (with `<a>` wrapping the animated visual content) into **two separate `amp-story-grid-layer` elements**:

1. **Layer 1** (`template="fill"`): Visual content with `animate-in` animations — no link wrapper
2. **Layer 2** (`template="fill"`): Empty `<a>` tag only — no animated children, so AMP never creates wrappers that block it

This matches the recommended AMP Stories pattern for page-level interactive elements.

## Test plan

- [x] All 10 story files pass `pnpm run validate` (AMP validator: 0 failures)
- [x] Visual design of the next-story page is unchanged (screenshot verified)
- [x] `document.elementFromPoint()` at left (50px), center (195px), and right (340px) of the screen all return `A.next-story-link` — confirming the link is the topmost element across the full screen width

https://claude.ai/code/session_01KuEJaEzoynfwvAnPJy4dnT

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuEJaEzoynfwvAnPJy4dnT)_