### PR TITLE
fix: make next-story title and CTA text actual clickable links

### DIFF
--- a/src/tentang-berbakti-kepada-orang-tua/index.html
+++ b/src/tentang-berbakti-kepada-orang-tua/index.html
@@ -200,9 +200,9 @@
 		}
 
 		.next-story-link {
-			display: block;
-			width: 100%;
-			height: 100%;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
 			text-decoration: none;
 			color: inherit;
 		}
@@ -293,15 +293,14 @@
 		<amp-story-page id="next-story">
 		<amp-story-grid-layer template="fill">
 			<div class="page">
-						<div class="panel cover">
-							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Silaturahmi</h2>
-							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
-						</div>
-					</div>
-		</amp-story-grid-layer>
-		<amp-story-grid-layer template="fill">
-			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-silaturahmi/" target="_blank" rel="noopener"></a>
+				<div class="panel cover">
+					<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
+					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-silaturahmi/" target="_blank" rel="noopener">
+						<h2 class="cover-title">Tentang Silaturahmi</h2>
+						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
+					</a>
+				</div>
+			</div>
 		</amp-story-grid-layer>
 		</amp-story-page>
 

--- a/src/tentang-berbakti-kepada-orang-tua/index.html
+++ b/src/tentang-berbakti-kepada-orang-tua/index.html
@@ -291,17 +291,18 @@
 		</amp-story-page>
 
 		<amp-story-page id="next-story">
-			<amp-story-grid-layer template="fill">
-				<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-silaturahmi/" target="_blank" rel="noopener">
-					<div class="page">
+		<amp-story-grid-layer template="fill">
+			<div class="page">
 						<div class="panel cover">
 							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
 							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Silaturahmi</h2>
 							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
 						</div>
 					</div>
-				</a>
-			</amp-story-grid-layer>
+		</amp-story-grid-layer>
+		<amp-story-grid-layer template="fill">
+			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-silaturahmi/" target="_blank" rel="noopener"></a>
+		</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-analytics type="gtag" data-credentials="include">

--- a/src/tentang-ikhlas/index.html
+++ b/src/tentang-ikhlas/index.html
@@ -291,17 +291,18 @@
 		</amp-story-page>
 
 		<amp-story-page id="next-story">
-			<amp-story-grid-layer template="fill">
-				<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-taubat/" target="_blank" rel="noopener">
-					<div class="page">
+		<amp-story-grid-layer template="fill">
+			<div class="page">
 						<div class="panel cover">
 							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
 							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Taubat</h2>
 							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
 						</div>
 					</div>
-				</a>
-			</amp-story-grid-layer>
+		</amp-story-grid-layer>
+		<amp-story-grid-layer template="fill">
+			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-taubat/" target="_blank" rel="noopener"></a>
+		</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-analytics type="gtag" data-credentials="include">

--- a/src/tentang-ikhlas/index.html
+++ b/src/tentang-ikhlas/index.html
@@ -200,9 +200,9 @@
 		}
 
 		.next-story-link {
-			display: block;
-			width: 100%;
-			height: 100%;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
 			text-decoration: none;
 			color: inherit;
 		}
@@ -293,15 +293,14 @@
 		<amp-story-page id="next-story">
 		<amp-story-grid-layer template="fill">
 			<div class="page">
-						<div class="panel cover">
-							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Taubat</h2>
-							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
-						</div>
-					</div>
-		</amp-story-grid-layer>
-		<amp-story-grid-layer template="fill">
-			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-taubat/" target="_blank" rel="noopener"></a>
+				<div class="panel cover">
+					<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
+					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-taubat/" target="_blank" rel="noopener">
+						<h2 class="cover-title">Tentang Taubat</h2>
+						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
+					</a>
+				</div>
+			</div>
 		</amp-story-grid-layer>
 		</amp-story-page>
 

--- a/src/tentang-jujur/index.html
+++ b/src/tentang-jujur/index.html
@@ -291,17 +291,18 @@
 		</amp-story-page>
 
 		<amp-story-page id="next-story">
-			<amp-story-grid-layer template="fill">
-				<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-berbakti-kepada-orang-tua/" target="_blank" rel="noopener">
-					<div class="page">
+		<amp-story-grid-layer template="fill">
+			<div class="page">
 						<div class="panel cover">
 							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
 							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Berbakti kepada Orang Tua</h2>
 							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
 						</div>
 					</div>
-				</a>
-			</amp-story-grid-layer>
+		</amp-story-grid-layer>
+		<amp-story-grid-layer template="fill">
+			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-berbakti-kepada-orang-tua/" target="_blank" rel="noopener"></a>
+		</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-analytics type="gtag" data-credentials="include">

--- a/src/tentang-jujur/index.html
+++ b/src/tentang-jujur/index.html
@@ -200,9 +200,9 @@
 		}
 
 		.next-story-link {
-			display: block;
-			width: 100%;
-			height: 100%;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
 			text-decoration: none;
 			color: inherit;
 		}
@@ -293,15 +293,14 @@
 		<amp-story-page id="next-story">
 		<amp-story-grid-layer template="fill">
 			<div class="page">
-						<div class="panel cover">
-							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Berbakti kepada Orang Tua</h2>
-							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
-						</div>
-					</div>
-		</amp-story-grid-layer>
-		<amp-story-grid-layer template="fill">
-			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-berbakti-kepada-orang-tua/" target="_blank" rel="noopener"></a>
+				<div class="panel cover">
+					<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
+					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-berbakti-kepada-orang-tua/" target="_blank" rel="noopener">
+						<h2 class="cover-title">Tentang Berbakti kepada Orang Tua</h2>
+						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
+					</a>
+				</div>
+			</div>
 		</amp-story-grid-layer>
 		</amp-story-page>
 

--- a/src/tentang-menuntut-ilmu/index.html
+++ b/src/tentang-menuntut-ilmu/index.html
@@ -143,9 +143,9 @@
 		}
 
 		.ns-link {
-			display: block;
-			width: 100%;
-			height: 100%;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
 			text-decoration: none;
 			color: #fff;
 		}
@@ -303,15 +303,14 @@
 		<amp-story-page id="next-story">
 		<amp-story-grid-layer template="fill">
 			<div class="ns-page">
-						<div class="ns-panel">
-							<p class="ns-kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-							<h2 class="ns-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Sedekah</h2>
-							<p class="ns-hint" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
-						</div>
-					</div>
-		</amp-story-grid-layer>
-		<amp-story-grid-layer template="fill">
-			<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-sedekah/" target="_blank" rel="noopener"></a>
+				<div class="ns-panel">
+					<p class="ns-kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
+					<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-sedekah/" target="_blank" rel="noopener">
+						<h2 class="ns-title">Tentang Sedekah</h2>
+						<p class="ns-hint">Ketuk untuk melanjutkan ↗</p>
+					</a>
+				</div>
+			</div>
 		</amp-story-grid-layer>
 		</amp-story-page>
 

--- a/src/tentang-menuntut-ilmu/index.html
+++ b/src/tentang-menuntut-ilmu/index.html
@@ -301,17 +301,18 @@
 
 
 		<amp-story-page id="next-story">
-			<amp-story-grid-layer template="fill">
-				<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-sedekah/" target="_blank" rel="noopener">
-					<div class="ns-page">
+		<amp-story-grid-layer template="fill">
+			<div class="ns-page">
 						<div class="ns-panel">
 							<p class="ns-kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
 							<h2 class="ns-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Sedekah</h2>
 							<p class="ns-hint" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
 						</div>
 					</div>
-				</a>
-			</amp-story-grid-layer>
+		</amp-story-grid-layer>
+		<amp-story-grid-layer template="fill">
+			<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-sedekah/" target="_blank" rel="noopener"></a>
+		</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-analytics type="gtag" data-credentials="include">

--- a/src/tentang-sabar/index.html
+++ b/src/tentang-sabar/index.html
@@ -128,9 +128,9 @@
 		}
 
 		.ns-link {
-			display: block;
-			width: 100%;
-			height: 100%;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
 			text-decoration: none;
 			color: #fff;
 		}
@@ -242,15 +242,14 @@
 		<amp-story-page id="next-story">
 		<amp-story-grid-layer template="fill">
 			<div class="ns-page">
-						<div class="ns-panel">
-							<p class="ns-kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-							<h2 class="ns-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Syukur</h2>
-							<p class="ns-hint" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
-						</div>
-					</div>
-		</amp-story-grid-layer>
-		<amp-story-grid-layer template="fill">
-			<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-syukur/" target="_blank" rel="noopener"></a>
+				<div class="ns-panel">
+					<p class="ns-kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
+					<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-syukur/" target="_blank" rel="noopener">
+						<h2 class="ns-title">Tentang Syukur</h2>
+						<p class="ns-hint">Ketuk untuk melanjutkan ↗</p>
+					</a>
+				</div>
+			</div>
 		</amp-story-grid-layer>
 		</amp-story-page>
 

--- a/src/tentang-sabar/index.html
+++ b/src/tentang-sabar/index.html
@@ -240,17 +240,18 @@
 		</amp-story-page>
 
 		<amp-story-page id="next-story">
-			<amp-story-grid-layer template="fill">
-				<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-syukur/" target="_blank" rel="noopener">
-					<div class="ns-page">
+		<amp-story-grid-layer template="fill">
+			<div class="ns-page">
 						<div class="ns-panel">
 							<p class="ns-kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
 							<h2 class="ns-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Syukur</h2>
 							<p class="ns-hint" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
 						</div>
 					</div>
-				</a>
-			</amp-story-grid-layer>
+		</amp-story-grid-layer>
+		<amp-story-grid-layer template="fill">
+			<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-syukur/" target="_blank" rel="noopener"></a>
+		</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-analytics type="gtag" data-credentials="include">

--- a/src/tentang-sedekah/index.html
+++ b/src/tentang-sedekah/index.html
@@ -318,17 +318,18 @@
 		</amp-story-page>
 
 		<amp-story-page id="next-story">
-			<amp-story-grid-layer template="fill">
-				<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-sabar/" target="_blank" rel="noopener">
-					<div class="ns-page">
+		<amp-story-grid-layer template="fill">
+			<div class="ns-page">
 						<div class="ns-panel">
 							<p class="ns-kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
 							<h2 class="ns-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Sabar</h2>
 							<p class="ns-hint" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
 						</div>
 					</div>
-				</a>
-			</amp-story-grid-layer>
+		</amp-story-grid-layer>
+		<amp-story-grid-layer template="fill">
+			<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-sabar/" target="_blank" rel="noopener"></a>
+		</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-analytics type="gtag" data-credentials="include">

--- a/src/tentang-sedekah/index.html
+++ b/src/tentang-sedekah/index.html
@@ -139,9 +139,9 @@
 		}
 
 		.ns-link {
-			display: block;
-			width: 100%;
-			height: 100%;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
 			text-decoration: none;
 			color: #fff;
 		}
@@ -320,15 +320,14 @@
 		<amp-story-page id="next-story">
 		<amp-story-grid-layer template="fill">
 			<div class="ns-page">
-						<div class="ns-panel">
-							<p class="ns-kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-							<h2 class="ns-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Sabar</h2>
-							<p class="ns-hint" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
-						</div>
-					</div>
-		</amp-story-grid-layer>
-		<amp-story-grid-layer template="fill">
-			<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-sabar/" target="_blank" rel="noopener"></a>
+				<div class="ns-panel">
+					<p class="ns-kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
+					<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-sabar/" target="_blank" rel="noopener">
+						<h2 class="ns-title">Tentang Sabar</h2>
+						<p class="ns-hint">Ketuk untuk melanjutkan ↗</p>
+					</a>
+				</div>
+			</div>
 		</amp-story-grid-layer>
 		</amp-story-page>
 

--- a/src/tentang-silaturahmi/index.html
+++ b/src/tentang-silaturahmi/index.html
@@ -291,17 +291,18 @@
 		</amp-story-page>
 
 		<amp-story-page id="next-story">
-			<amp-story-grid-layer template="fill">
-				<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-menuntut-ilmu/" target="_blank" rel="noopener">
-					<div class="page">
+		<amp-story-grid-layer template="fill">
+			<div class="page">
 						<div class="panel cover">
 							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
 							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Menuntut Ilmu</h2>
 							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
 						</div>
 					</div>
-				</a>
-			</amp-story-grid-layer>
+		</amp-story-grid-layer>
+		<amp-story-grid-layer template="fill">
+			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-menuntut-ilmu/" target="_blank" rel="noopener"></a>
+		</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-analytics type="gtag" data-credentials="include">

--- a/src/tentang-silaturahmi/index.html
+++ b/src/tentang-silaturahmi/index.html
@@ -200,9 +200,9 @@
 		}
 
 		.next-story-link {
-			display: block;
-			width: 100%;
-			height: 100%;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
 			text-decoration: none;
 			color: inherit;
 		}
@@ -293,15 +293,14 @@
 		<amp-story-page id="next-story">
 		<amp-story-grid-layer template="fill">
 			<div class="page">
-						<div class="panel cover">
-							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Menuntut Ilmu</h2>
-							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
-						</div>
-					</div>
-		</amp-story-grid-layer>
-		<amp-story-grid-layer template="fill">
-			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-menuntut-ilmu/" target="_blank" rel="noopener"></a>
+				<div class="panel cover">
+					<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
+					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-menuntut-ilmu/" target="_blank" rel="noopener">
+						<h2 class="cover-title">Tentang Menuntut Ilmu</h2>
+						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
+					</a>
+				</div>
+			</div>
 		</amp-story-grid-layer>
 		</amp-story-page>
 

--- a/src/tentang-syukur/index.html
+++ b/src/tentang-syukur/index.html
@@ -291,17 +291,18 @@
 		</amp-story-page>
 
 		<amp-story-page id="next-story">
-			<amp-story-grid-layer template="fill">
-				<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-tawakal/" target="_blank" rel="noopener">
-					<div class="page">
+		<amp-story-grid-layer template="fill">
+			<div class="page">
 						<div class="panel cover">
 							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
 							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Tawakal</h2>
 							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
 						</div>
 					</div>
-				</a>
-			</amp-story-grid-layer>
+		</amp-story-grid-layer>
+		<amp-story-grid-layer template="fill">
+			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-tawakal/" target="_blank" rel="noopener"></a>
+		</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-analytics type="gtag" data-credentials="include">

--- a/src/tentang-syukur/index.html
+++ b/src/tentang-syukur/index.html
@@ -200,9 +200,9 @@
 		}
 
 		.next-story-link {
-			display: block;
-			width: 100%;
-			height: 100%;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
 			text-decoration: none;
 			color: inherit;
 		}
@@ -293,15 +293,14 @@
 		<amp-story-page id="next-story">
 		<amp-story-grid-layer template="fill">
 			<div class="page">
-						<div class="panel cover">
-							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Tawakal</h2>
-							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
-						</div>
-					</div>
-		</amp-story-grid-layer>
-		<amp-story-grid-layer template="fill">
-			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-tawakal/" target="_blank" rel="noopener"></a>
+				<div class="panel cover">
+					<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
+					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-tawakal/" target="_blank" rel="noopener">
+						<h2 class="cover-title">Tentang Tawakal</h2>
+						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
+					</a>
+				</div>
+			</div>
 		</amp-story-grid-layer>
 		</amp-story-page>
 

--- a/src/tentang-taubat/index.html
+++ b/src/tentang-taubat/index.html
@@ -291,17 +291,18 @@
 		</amp-story-page>
 
 		<amp-story-page id="next-story">
-			<amp-story-grid-layer template="fill">
-				<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-jujur/" target="_blank" rel="noopener">
-					<div class="page">
+		<amp-story-grid-layer template="fill">
+			<div class="page">
 						<div class="panel cover">
 							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
 							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Jujur</h2>
 							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
 						</div>
 					</div>
-				</a>
-			</amp-story-grid-layer>
+		</amp-story-grid-layer>
+		<amp-story-grid-layer template="fill">
+			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-jujur/" target="_blank" rel="noopener"></a>
+		</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-analytics type="gtag" data-credentials="include">

--- a/src/tentang-taubat/index.html
+++ b/src/tentang-taubat/index.html
@@ -200,9 +200,9 @@
 		}
 
 		.next-story-link {
-			display: block;
-			width: 100%;
-			height: 100%;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
 			text-decoration: none;
 			color: inherit;
 		}
@@ -293,15 +293,14 @@
 		<amp-story-page id="next-story">
 		<amp-story-grid-layer template="fill">
 			<div class="page">
-						<div class="panel cover">
-							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Jujur</h2>
-							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
-						</div>
-					</div>
-		</amp-story-grid-layer>
-		<amp-story-grid-layer template="fill">
-			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-jujur/" target="_blank" rel="noopener"></a>
+				<div class="panel cover">
+					<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
+					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-jujur/" target="_blank" rel="noopener">
+						<h2 class="cover-title">Tentang Jujur</h2>
+						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
+					</a>
+				</div>
+			</div>
 		</amp-story-grid-layer>
 		</amp-story-page>
 

--- a/src/tentang-tawakal/index.html
+++ b/src/tentang-tawakal/index.html
@@ -291,17 +291,18 @@
 		</amp-story-page>
 
 		<amp-story-page id="next-story">
-			<amp-story-grid-layer template="fill">
-				<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-ikhlas/" target="_blank" rel="noopener">
-					<div class="page">
+		<amp-story-grid-layer template="fill">
+			<div class="page">
 						<div class="panel cover">
 							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
 							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Ikhlas</h2>
 							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
 						</div>
 					</div>
-				</a>
-			</amp-story-grid-layer>
+		</amp-story-grid-layer>
+		<amp-story-grid-layer template="fill">
+			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-ikhlas/" target="_blank" rel="noopener"></a>
+		</amp-story-grid-layer>
 		</amp-story-page>
 
 		<amp-analytics type="gtag" data-credentials="include">

--- a/src/tentang-tawakal/index.html
+++ b/src/tentang-tawakal/index.html
@@ -200,9 +200,9 @@
 		}
 
 		.next-story-link {
-			display: block;
-			width: 100%;
-			height: 100%;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
 			text-decoration: none;
 			color: inherit;
 		}
@@ -293,15 +293,14 @@
 		<amp-story-page id="next-story">
 		<amp-story-grid-layer template="fill">
 			<div class="page">
-						<div class="panel cover">
-							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Ikhlas</h2>
-							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
-						</div>
-					</div>
-		</amp-story-grid-layer>
-		<amp-story-grid-layer template="fill">
-			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-ikhlas/" target="_blank" rel="noopener"></a>
+				<div class="panel cover">
+					<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
+					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-ikhlas/" target="_blank" rel="noopener">
+						<h2 class="cover-title">Tentang Ikhlas</h2>
+						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
+					</a>
+				</div>
+			</div>
 		</amp-story-grid-layer>
 		</amp-story-page>
 


### PR DESCRIPTION
## Summary

- Replace the invisible full-screen `<a>` workaround with natural, visible links
- The story title (`<h2>`) and "Ketuk untuk melanjutkan ↗" text are now wrapped in an `<a target="_blank">` — the elements users actually see and tap
- Removed `animate-in` from h2 and p inside the link (AMP does not allow animate-in on elements nested inside an `<a>` in story layers)
- The kicker "Cerita Selanjutnya" retains its fade-in animation as it is outside the link

## Why this approach

The invisible full-screen link had two problems:
1. AMP animation wrappers rendered on top of and outside the `<a>`, intercepting clicks
2. AMP's capture-phase event listener on `amp-story` processed taps before they reached the link

Making the visible text elements themselves the links is the simplest and most natural fix — no overlays, no workarounds.

## Test plan

- [x] All 10 stories pass AMP validation (`pnpm run validate`: 0 failures)
- [x] Visual design unchanged — title and "Ketuk" text still display correctly
- [x] `document.elementFromPoint()` at center of next-story page returns `A.next-story-link`

https://claude.ai/code/session_01KuEJaEzoynfwvAnPJy4dnT

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuEJaEzoynfwvAnPJy4dnT)_