### PR TITLE
fix: make story title and CTA text the actual clickable links

### DIFF
--- a/src/tentang-berbakti-kepada-orang-tua/index.html
+++ b/src/tentang-berbakti-kepada-orang-tua/index.html
@@ -200,9 +200,9 @@
 		}
 
 		.next-story-link {
-			display: block;
-			width: 100%;
-			height: 100%;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
 			text-decoration: none;
 			color: inherit;
 		}
@@ -293,15 +293,14 @@
 		<amp-story-page id="next-story">
 		<amp-story-grid-layer template="fill">
 			<div class="page">
-						<div class="panel cover">
-							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Silaturahmi</h2>
-							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
-						</div>
-					</div>
-		</amp-story-grid-layer>
-		<amp-story-grid-layer template="fill">
-			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-silaturahmi/" target="_blank" rel="noopener"></a>
+				<div class="panel cover">
+					<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
+					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-silaturahmi/" target="_blank" rel="noopener">
+						<h2 class="cover-title">Tentang Silaturahmi</h2>
+						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
+					</a>
+				</div>
+			</div>
 		</amp-story-grid-layer>
 		</amp-story-page>
 

--- a/src/tentang-ikhlas/index.html
+++ b/src/tentang-ikhlas/index.html
@@ -200,9 +200,9 @@
 		}
 
 		.next-story-link {
-			display: block;
-			width: 100%;
-			height: 100%;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
 			text-decoration: none;
 			color: inherit;
 		}
@@ -293,15 +293,14 @@
 		<amp-story-page id="next-story">
 		<amp-story-grid-layer template="fill">
 			<div class="page">
-						<div class="panel cover">
-							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Taubat</h2>
-							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
-						</div>
-					</div>
-		</amp-story-grid-layer>
-		<amp-story-grid-layer template="fill">
-			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-taubat/" target="_blank" rel="noopener"></a>
+				<div class="panel cover">
+					<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
+					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-taubat/" target="_blank" rel="noopener">
+						<h2 class="cover-title">Tentang Taubat</h2>
+						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
+					</a>
+				</div>
+			</div>
 		</amp-story-grid-layer>
 		</amp-story-page>
 

--- a/src/tentang-jujur/index.html
+++ b/src/tentang-jujur/index.html
@@ -200,9 +200,9 @@
 		}
 
 		.next-story-link {
-			display: block;
-			width: 100%;
-			height: 100%;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
 			text-decoration: none;
 			color: inherit;
 		}
@@ -293,15 +293,14 @@
 		<amp-story-page id="next-story">
 		<amp-story-grid-layer template="fill">
 			<div class="page">
-						<div class="panel cover">
-							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Berbakti kepada Orang Tua</h2>
-							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
-						</div>
-					</div>
-		</amp-story-grid-layer>
-		<amp-story-grid-layer template="fill">
-			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-berbakti-kepada-orang-tua/" target="_blank" rel="noopener"></a>
+				<div class="panel cover">
+					<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
+					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-berbakti-kepada-orang-tua/" target="_blank" rel="noopener">
+						<h2 class="cover-title">Tentang Berbakti kepada Orang Tua</h2>
+						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
+					</a>
+				</div>
+			</div>
 		</amp-story-grid-layer>
 		</amp-story-page>
 

--- a/src/tentang-menuntut-ilmu/index.html
+++ b/src/tentang-menuntut-ilmu/index.html
@@ -143,9 +143,9 @@
 		}
 
 		.ns-link {
-			display: block;
-			width: 100%;
-			height: 100%;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
 			text-decoration: none;
 			color: #fff;
 		}
@@ -303,15 +303,14 @@
 		<amp-story-page id="next-story">
 		<amp-story-grid-layer template="fill">
 			<div class="ns-page">
-						<div class="ns-panel">
-							<p class="ns-kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-							<h2 class="ns-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Sedekah</h2>
-							<p class="ns-hint" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
-						</div>
-					</div>
-		</amp-story-grid-layer>
-		<amp-story-grid-layer template="fill">
-			<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-sedekah/" target="_blank" rel="noopener"></a>
+				<div class="ns-panel">
+					<p class="ns-kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
+					<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-sedekah/" target="_blank" rel="noopener">
+						<h2 class="ns-title">Tentang Sedekah</h2>
+						<p class="ns-hint">Ketuk untuk melanjutkan ↗</p>
+					</a>
+				</div>
+			</div>
 		</amp-story-grid-layer>
 		</amp-story-page>
 

--- a/src/tentang-sabar/index.html
+++ b/src/tentang-sabar/index.html
@@ -128,9 +128,9 @@
 		}
 
 		.ns-link {
-			display: block;
-			width: 100%;
-			height: 100%;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
 			text-decoration: none;
 			color: #fff;
 		}
@@ -242,15 +242,14 @@
 		<amp-story-page id="next-story">
 		<amp-story-grid-layer template="fill">
 			<div class="ns-page">
-						<div class="ns-panel">
-							<p class="ns-kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-							<h2 class="ns-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Syukur</h2>
-							<p class="ns-hint" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
-						</div>
-					</div>
-		</amp-story-grid-layer>
-		<amp-story-grid-layer template="fill">
-			<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-syukur/" target="_blank" rel="noopener"></a>
+				<div class="ns-panel">
+					<p class="ns-kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
+					<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-syukur/" target="_blank" rel="noopener">
+						<h2 class="ns-title">Tentang Syukur</h2>
+						<p class="ns-hint">Ketuk untuk melanjutkan ↗</p>
+					</a>
+				</div>
+			</div>
 		</amp-story-grid-layer>
 		</amp-story-page>
 

--- a/src/tentang-sedekah/index.html
+++ b/src/tentang-sedekah/index.html
@@ -139,9 +139,9 @@
 		}
 
 		.ns-link {
-			display: block;
-			width: 100%;
-			height: 100%;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
 			text-decoration: none;
 			color: #fff;
 		}
@@ -320,15 +320,14 @@
 		<amp-story-page id="next-story">
 		<amp-story-grid-layer template="fill">
 			<div class="ns-page">
-						<div class="ns-panel">
-							<p class="ns-kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-							<h2 class="ns-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Sabar</h2>
-							<p class="ns-hint" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
-						</div>
-					</div>
-		</amp-story-grid-layer>
-		<amp-story-grid-layer template="fill">
-			<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-sabar/" target="_blank" rel="noopener"></a>
+				<div class="ns-panel">
+					<p class="ns-kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
+					<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-sabar/" target="_blank" rel="noopener">
+						<h2 class="ns-title">Tentang Sabar</h2>
+						<p class="ns-hint">Ketuk untuk melanjutkan ↗</p>
+					</a>
+				</div>
+			</div>
 		</amp-story-grid-layer>
 		</amp-story-page>
 

--- a/src/tentang-silaturahmi/index.html
+++ b/src/tentang-silaturahmi/index.html
@@ -200,9 +200,9 @@
 		}
 
 		.next-story-link {
-			display: block;
-			width: 100%;
-			height: 100%;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
 			text-decoration: none;
 			color: inherit;
 		}
@@ -293,15 +293,14 @@
 		<amp-story-page id="next-story">
 		<amp-story-grid-layer template="fill">
 			<div class="page">
-						<div class="panel cover">
-							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Menuntut Ilmu</h2>
-							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
-						</div>
-					</div>
-		</amp-story-grid-layer>
-		<amp-story-grid-layer template="fill">
-			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-menuntut-ilmu/" target="_blank" rel="noopener"></a>
+				<div class="panel cover">
+					<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
+					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-menuntut-ilmu/" target="_blank" rel="noopener">
+						<h2 class="cover-title">Tentang Menuntut Ilmu</h2>
+						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
+					</a>
+				</div>
+			</div>
 		</amp-story-grid-layer>
 		</amp-story-page>
 

--- a/src/tentang-syukur/index.html
+++ b/src/tentang-syukur/index.html
@@ -200,9 +200,9 @@
 		}
 
 		.next-story-link {
-			display: block;
-			width: 100%;
-			height: 100%;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
 			text-decoration: none;
 			color: inherit;
 		}
@@ -293,15 +293,14 @@
 		<amp-story-page id="next-story">
 		<amp-story-grid-layer template="fill">
 			<div class="page">
-						<div class="panel cover">
-							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Tawakal</h2>
-							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
-						</div>
-					</div>
-		</amp-story-grid-layer>
-		<amp-story-grid-layer template="fill">
-			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-tawakal/" target="_blank" rel="noopener"></a>
+				<div class="panel cover">
+					<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
+					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-tawakal/" target="_blank" rel="noopener">
+						<h2 class="cover-title">Tentang Tawakal</h2>
+						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
+					</a>
+				</div>
+			</div>
 		</amp-story-grid-layer>
 		</amp-story-page>
 

--- a/src/tentang-taubat/index.html
+++ b/src/tentang-taubat/index.html
@@ -200,9 +200,9 @@
 		}
 
 		.next-story-link {
-			display: block;
-			width: 100%;
-			height: 100%;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
 			text-decoration: none;
 			color: inherit;
 		}
@@ -293,15 +293,14 @@
 		<amp-story-page id="next-story">
 		<amp-story-grid-layer template="fill">
 			<div class="page">
-						<div class="panel cover">
-							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Jujur</h2>
-							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
-						</div>
-					</div>
-		</amp-story-grid-layer>
-		<amp-story-grid-layer template="fill">
-			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-jujur/" target="_blank" rel="noopener"></a>
+				<div class="panel cover">
+					<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
+					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-jujur/" target="_blank" rel="noopener">
+						<h2 class="cover-title">Tentang Jujur</h2>
+						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
+					</a>
+				</div>
+			</div>
 		</amp-story-grid-layer>
 		</amp-story-page>
 

--- a/src/tentang-tawakal/index.html
+++ b/src/tentang-tawakal/index.html
@@ -200,9 +200,9 @@
 		}
 
 		.next-story-link {
-			display: block;
-			width: 100%;
-			height: 100%;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
 			text-decoration: none;
 			color: inherit;
 		}
@@ -293,15 +293,14 @@
 		<amp-story-page id="next-story">
 		<amp-story-grid-layer template="fill">
 			<div class="page">
-						<div class="panel cover">
-							<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-							<h2 class="cover-title" animate-in="fly-in-bottom" animate-in-duration="0.8s" animate-in-timing-function="ease-out" animate-in-delay="0.4s">Tentang Ikhlas</h2>
-							<p class="cover-sub" animate-in="fade-in" animate-in-duration="0.7s" animate-in-timing-function="ease-out" animate-in-delay="0.85s">Ketuk untuk melanjutkan ↗</p>
-						</div>
-					</div>
-		</amp-story-grid-layer>
-		<amp-story-grid-layer template="fill">
-			<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-ikhlas/" target="_blank" rel="noopener"></a>
+				<div class="panel cover">
+					<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
+					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-ikhlas/" target="_blank" rel="noopener">
+						<h2 class="cover-title">Tentang Ikhlas</h2>
+						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
+					</a>
+				</div>
+			</div>
 		</amp-story-grid-layer>
 		</amp-story-page>
 


### PR DESCRIPTION
## Summary

- Replaces the invisible full-screen `<a>` workaround with natural, visible links
- The story title (`<h2>`) and "Ketuk untuk melanjutkan ↗" are now wrapped in an `<a target="_blank">` — the elements users actually see and tap
- `animate-in` removed from h2 and the hint paragraph inside the link (AMP does not allow animate-in on elements nested inside `<a>` in story grid layers)
- "Cerita Selanjutnya" kicker keeps its fade-in animation (it's outside the link)
- `.next-story-link` / `.ns-link` CSS updated from full-screen block to flex column

## Test plan

- [x] All 10 stories pass AMP validation (`pnpm run validate`: 0 failures)
- [x] Visual design unchanged — title and "Ketuk" text display correctly
- [x] `document.elementFromPoint()` at center of next-story page returns `A.next-story-link`

https://claude.ai/code/session_01KuEJaEzoynfwvAnPJy4dnT

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuEJaEzoynfwvAnPJy4dnT)_