### PR TITLE
fix: correct next-story link order across all stories

### DIFF
--- a/content.json
+++ b/content.json
@@ -6,39 +6,11 @@
   },
   "stories": [
     {
-      "slug": "tentang-syukur",
-      "title": "Tentang Syukur",
-      "description": "Kumpulan quote tentang syukur yang diambil dari ayat-ayat Al-Quran",
-      "publishedDate": "2026-04-15",
-      "gradient": "linear-gradient(135deg, #ec4899 0%, #ef4444 50%, #fbbf24 100%)"
-    },
-    {
-      "slug": "tentang-tawakal",
-      "title": "Tentang Tawakal",
-      "description": "Kumpulan quote tentang tawakal yang diambil dari ayat-ayat Al-Quran",
-      "publishedDate": "2026-04-22",
-      "gradient": "linear-gradient(135deg, #10b981 0%, #14b8a6 50%, #06b6d4 100%)"
-    },
-    {
-      "slug": "tentang-ikhlas",
-      "title": "Tentang Ikhlas",
-      "description": "Kumpulan quote tentang ikhlas yang diambil dari ayat-ayat Al-Quran",
-      "publishedDate": "2026-04-29",
-      "gradient": "linear-gradient(135deg, #a855f7 0%, #8b5cf6 50%, #4f46e5 100%)"
-    },
-    {
-      "slug": "tentang-taubat",
-      "title": "Tentang Taubat",
-      "description": "Kumpulan quote tentang taubat yang diambil dari ayat-ayat Al-Quran",
-      "publishedDate": "2026-05-06",
-      "gradient": "linear-gradient(135deg, #1d4ed8 0%, #4338ca 50%, #6b21a8 100%)"
-    },
-    {
-      "slug": "tentang-jujur",
-      "title": "Tentang Jujur",
-      "description": "Kumpulan quote tentang jujur yang diambil dari ayat-ayat Al-Quran",
-      "publishedDate": "2026-05-13",
-      "gradient": "linear-gradient(135deg, #84cc16 0%, #22c55e 50%, #059669 100%)"
+      "slug": "tentang-silaturahmi",
+      "title": "Tentang Silaturahmi",
+      "description": "Kumpulan quote tentang silaturahmi yang diambil dari ayat-ayat Al-Quran",
+      "publishedDate": "2026-05-27",
+      "gradient": "linear-gradient(135deg, #22d3ee 0%, #0ea5e9 50%, #2563eb 100%)"
     },
     {
       "slug": "tentang-berbakti-kepada-orang-tua",
@@ -48,11 +20,39 @@
       "gradient": "linear-gradient(135deg, #fb7185 0%, #d946ef 50%, #6366f1 100%)"
     },
     {
-      "slug": "tentang-silaturahmi",
-      "title": "Tentang Silaturahmi",
-      "description": "Kumpulan quote tentang silaturahmi yang diambil dari ayat-ayat Al-Quran",
-      "publishedDate": "2026-05-27",
-      "gradient": "linear-gradient(135deg, #22d3ee 0%, #0ea5e9 50%, #2563eb 100%)"
+      "slug": "tentang-jujur",
+      "title": "Tentang Jujur",
+      "description": "Kumpulan quote tentang jujur yang diambil dari ayat-ayat Al-Quran",
+      "publishedDate": "2026-05-13",
+      "gradient": "linear-gradient(135deg, #84cc16 0%, #22c55e 50%, #059669 100%)"
+    },
+    {
+      "slug": "tentang-taubat",
+      "title": "Tentang Taubat",
+      "description": "Kumpulan quote tentang taubat yang diambil dari ayat-ayat Al-Quran",
+      "publishedDate": "2026-05-06",
+      "gradient": "linear-gradient(135deg, #1d4ed8 0%, #4338ca 50%, #6b21a8 100%)"
+    },
+    {
+      "slug": "tentang-ikhlas",
+      "title": "Tentang Ikhlas",
+      "description": "Kumpulan quote tentang ikhlas yang diambil dari ayat-ayat Al-Quran",
+      "publishedDate": "2026-04-29",
+      "gradient": "linear-gradient(135deg, #a855f7 0%, #8b5cf6 50%, #4f46e5 100%)"
+    },
+    {
+      "slug": "tentang-tawakal",
+      "title": "Tentang Tawakal",
+      "description": "Kumpulan quote tentang tawakal yang diambil dari ayat-ayat Al-Quran",
+      "publishedDate": "2026-04-22",
+      "gradient": "linear-gradient(135deg, #10b981 0%, #14b8a6 50%, #06b6d4 100%)"
+    },
+    {
+      "slug": "tentang-syukur",
+      "title": "Tentang Syukur",
+      "description": "Kumpulan quote tentang syukur yang diambil dari ayat-ayat Al-Quran",
+      "publishedDate": "2026-04-15",
+      "gradient": "linear-gradient(135deg, #ec4899 0%, #ef4444 50%, #fbbf24 100%)"
     },
     {
       "slug": "tentang-menuntut-ilmu",

--- a/src/tentang-berbakti-kepada-orang-tua/index.html
+++ b/src/tentang-berbakti-kepada-orang-tua/index.html
@@ -295,8 +295,8 @@
 			<div class="page">
 				<div class="panel cover">
 					<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-silaturahmi/" target="_blank" rel="noopener">
-						<h2 class="cover-title">Tentang Silaturahmi</h2>
+					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-jujur/" target="_blank" rel="noopener">
+						<h2 class="cover-title">Tentang Jujur</h2>
 						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
 					</a>
 				</div>

--- a/src/tentang-berbakti-kepada-orang-tua/index.html
+++ b/src/tentang-berbakti-kepada-orang-tua/index.html
@@ -206,6 +206,17 @@
 			text-decoration: none;
 			color: inherit;
 		}
+
+		.home-link {
+			display: block;
+			margin-top: 1.5rem;
+			font-size: 0.8rem;
+			letter-spacing: 0.08em;
+			color: #fff;
+			text-decoration: underline;
+			text-underline-offset: 3px;
+			opacity: 0.75;
+		}
 	</style>
 
 	<script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -299,6 +310,7 @@
 						<h2 class="cover-title">Tentang Jujur</h2>
 						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
 					</a>
+					<a class="home-link" href="https://www.baca-quran.id/stories/" target="_blank" rel="noopener">← Semua Cerita</a>
 				</div>
 			</div>
 		</amp-story-grid-layer>

--- a/src/tentang-ikhlas/index.html
+++ b/src/tentang-ikhlas/index.html
@@ -295,8 +295,8 @@
 			<div class="page">
 				<div class="panel cover">
 					<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-taubat/" target="_blank" rel="noopener">
-						<h2 class="cover-title">Tentang Taubat</h2>
+					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-tawakal/" target="_blank" rel="noopener">
+						<h2 class="cover-title">Tentang Tawakal</h2>
 						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
 					</a>
 				</div>

--- a/src/tentang-ikhlas/index.html
+++ b/src/tentang-ikhlas/index.html
@@ -206,6 +206,17 @@
 			text-decoration: none;
 			color: inherit;
 		}
+
+		.home-link {
+			display: block;
+			margin-top: 1.5rem;
+			font-size: 0.8rem;
+			letter-spacing: 0.08em;
+			color: #fff;
+			text-decoration: underline;
+			text-underline-offset: 3px;
+			opacity: 0.75;
+		}
 	</style>
 
 	<script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -299,6 +310,7 @@
 						<h2 class="cover-title">Tentang Tawakal</h2>
 						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
 					</a>
+					<a class="home-link" href="https://www.baca-quran.id/stories/" target="_blank" rel="noopener">← Semua Cerita</a>
 				</div>
 			</div>
 		</amp-story-grid-layer>

--- a/src/tentang-jujur/index.html
+++ b/src/tentang-jujur/index.html
@@ -295,8 +295,8 @@
 			<div class="page">
 				<div class="panel cover">
 					<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-berbakti-kepada-orang-tua/" target="_blank" rel="noopener">
-						<h2 class="cover-title">Tentang Berbakti kepada Orang Tua</h2>
+					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-taubat/" target="_blank" rel="noopener">
+						<h2 class="cover-title">Tentang Taubat</h2>
 						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
 					</a>
 				</div>

--- a/src/tentang-jujur/index.html
+++ b/src/tentang-jujur/index.html
@@ -206,6 +206,17 @@
 			text-decoration: none;
 			color: inherit;
 		}
+
+		.home-link {
+			display: block;
+			margin-top: 1.5rem;
+			font-size: 0.8rem;
+			letter-spacing: 0.08em;
+			color: #fff;
+			text-decoration: underline;
+			text-underline-offset: 3px;
+			opacity: 0.75;
+		}
 	</style>
 
 	<script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -299,6 +310,7 @@
 						<h2 class="cover-title">Tentang Taubat</h2>
 						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
 					</a>
+					<a class="home-link" href="https://www.baca-quran.id/stories/" target="_blank" rel="noopener">← Semua Cerita</a>
 				</div>
 			</div>
 		</amp-story-grid-layer>

--- a/src/tentang-menuntut-ilmu/index.html
+++ b/src/tentang-menuntut-ilmu/index.html
@@ -191,6 +191,17 @@
 			opacity: 0.8;
 			margin: 0;
 		}
+
+		.ns-home {
+			display: block;
+			margin-top: 1.2rem;
+			font-size: 0.8rem;
+			letter-spacing: 0.08em;
+			color: #fff;
+			text-decoration: underline;
+			text-underline-offset: 3px;
+			opacity: 0.75;
+		}
 	</style>
 
 	<script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -309,6 +320,7 @@
 						<h2 class="ns-title">Tentang Sedekah</h2>
 						<p class="ns-hint">Ketuk untuk melanjutkan ↗</p>
 					</a>
+					<a class="ns-home" href="https://www.baca-quran.id/stories/" target="_blank" rel="noopener">← Semua Cerita</a>
 				</div>
 			</div>
 		</amp-story-grid-layer>

--- a/src/tentang-sabar/index.html
+++ b/src/tentang-sabar/index.html
@@ -176,6 +176,17 @@
 			opacity: 0.8;
 			margin: 0;
 		}
+
+		.ns-home {
+			display: block;
+			margin-top: 1.2rem;
+			font-size: 0.8rem;
+			letter-spacing: 0.08em;
+			color: #fff;
+			text-decoration: underline;
+			text-underline-offset: 3px;
+			opacity: 0.75;
+		}
 	</style>
 
 	<script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -248,6 +259,7 @@
 						<h2 class="ns-title">Tentang Silaturahmi</h2>
 						<p class="ns-hint">Ketuk untuk melanjutkan ↗</p>
 					</a>
+					<a class="ns-home" href="https://www.baca-quran.id/stories/" target="_blank" rel="noopener">← Semua Cerita</a>
 				</div>
 			</div>
 		</amp-story-grid-layer>

--- a/src/tentang-sabar/index.html
+++ b/src/tentang-sabar/index.html
@@ -244,8 +244,8 @@
 			<div class="ns-page">
 				<div class="ns-panel">
 					<p class="ns-kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-					<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-syukur/" target="_blank" rel="noopener">
-						<h2 class="ns-title">Tentang Syukur</h2>
+					<a class="ns-link" href="https://www.baca-quran.id/stories/tentang-silaturahmi/" target="_blank" rel="noopener">
+						<h2 class="ns-title">Tentang Silaturahmi</h2>
 						<p class="ns-hint">Ketuk untuk melanjutkan ↗</p>
 					</a>
 				</div>

--- a/src/tentang-sedekah/index.html
+++ b/src/tentang-sedekah/index.html
@@ -187,6 +187,17 @@
 			opacity: 0.8;
 			margin: 0;
 		}
+
+		.ns-home {
+			display: block;
+			margin-top: 1.2rem;
+			font-size: 0.8rem;
+			letter-spacing: 0.08em;
+			color: #fff;
+			text-decoration: underline;
+			text-underline-offset: 3px;
+			opacity: 0.75;
+		}
 	</style>
 
 	<script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -326,6 +337,7 @@
 						<h2 class="ns-title">Tentang Sabar</h2>
 						<p class="ns-hint">Ketuk untuk melanjutkan ↗</p>
 					</a>
+					<a class="ns-home" href="https://www.baca-quran.id/stories/" target="_blank" rel="noopener">← Semua Cerita</a>
 				</div>
 			</div>
 		</amp-story-grid-layer>

--- a/src/tentang-silaturahmi/index.html
+++ b/src/tentang-silaturahmi/index.html
@@ -295,8 +295,8 @@
 			<div class="page">
 				<div class="panel cover">
 					<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-menuntut-ilmu/" target="_blank" rel="noopener">
-						<h2 class="cover-title">Tentang Menuntut Ilmu</h2>
+					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-berbakti-kepada-orang-tua/" target="_blank" rel="noopener">
+						<h2 class="cover-title">Tentang Berbakti kepada Orang Tua</h2>
 						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
 					</a>
 				</div>

--- a/src/tentang-silaturahmi/index.html
+++ b/src/tentang-silaturahmi/index.html
@@ -206,6 +206,17 @@
 			text-decoration: none;
 			color: inherit;
 		}
+
+		.home-link {
+			display: block;
+			margin-top: 1.5rem;
+			font-size: 0.8rem;
+			letter-spacing: 0.08em;
+			color: #fff;
+			text-decoration: underline;
+			text-underline-offset: 3px;
+			opacity: 0.75;
+		}
 	</style>
 
 	<script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -299,6 +310,7 @@
 						<h2 class="cover-title">Tentang Berbakti kepada Orang Tua</h2>
 						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
 					</a>
+					<a class="home-link" href="https://www.baca-quran.id/stories/" target="_blank" rel="noopener">← Semua Cerita</a>
 				</div>
 			</div>
 		</amp-story-grid-layer>

--- a/src/tentang-syukur/index.html
+++ b/src/tentang-syukur/index.html
@@ -206,6 +206,17 @@
 			text-decoration: none;
 			color: inherit;
 		}
+
+		.home-link {
+			display: block;
+			margin-top: 1.5rem;
+			font-size: 0.8rem;
+			letter-spacing: 0.08em;
+			color: #fff;
+			text-decoration: underline;
+			text-underline-offset: 3px;
+			opacity: 0.75;
+		}
 	</style>
 
 	<script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -299,6 +310,7 @@
 						<h2 class="cover-title">Tentang Menuntut Ilmu</h2>
 						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
 					</a>
+					<a class="home-link" href="https://www.baca-quran.id/stories/" target="_blank" rel="noopener">← Semua Cerita</a>
 				</div>
 			</div>
 		</amp-story-grid-layer>

--- a/src/tentang-syukur/index.html
+++ b/src/tentang-syukur/index.html
@@ -295,8 +295,8 @@
 			<div class="page">
 				<div class="panel cover">
 					<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-tawakal/" target="_blank" rel="noopener">
-						<h2 class="cover-title">Tentang Tawakal</h2>
+					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-menuntut-ilmu/" target="_blank" rel="noopener">
+						<h2 class="cover-title">Tentang Menuntut Ilmu</h2>
 						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
 					</a>
 				</div>

--- a/src/tentang-taubat/index.html
+++ b/src/tentang-taubat/index.html
@@ -206,6 +206,17 @@
 			text-decoration: none;
 			color: inherit;
 		}
+
+		.home-link {
+			display: block;
+			margin-top: 1.5rem;
+			font-size: 0.8rem;
+			letter-spacing: 0.08em;
+			color: #fff;
+			text-decoration: underline;
+			text-underline-offset: 3px;
+			opacity: 0.75;
+		}
 	</style>
 
 	<script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -299,6 +310,7 @@
 						<h2 class="cover-title">Tentang Ikhlas</h2>
 						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
 					</a>
+					<a class="home-link" href="https://www.baca-quran.id/stories/" target="_blank" rel="noopener">← Semua Cerita</a>
 				</div>
 			</div>
 		</amp-story-grid-layer>

--- a/src/tentang-taubat/index.html
+++ b/src/tentang-taubat/index.html
@@ -295,8 +295,8 @@
 			<div class="page">
 				<div class="panel cover">
 					<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-jujur/" target="_blank" rel="noopener">
-						<h2 class="cover-title">Tentang Jujur</h2>
+					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-ikhlas/" target="_blank" rel="noopener">
+						<h2 class="cover-title">Tentang Ikhlas</h2>
 						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
 					</a>
 				</div>

--- a/src/tentang-tawakal/index.html
+++ b/src/tentang-tawakal/index.html
@@ -295,8 +295,8 @@
 			<div class="page">
 				<div class="panel cover">
 					<p class="kicker" animate-in="fade-in" animate-in-duration="0.6s" animate-in-timing-function="ease-out" animate-in-delay="0.15s">Cerita Selanjutnya</p>
-					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-ikhlas/" target="_blank" rel="noopener">
-						<h2 class="cover-title">Tentang Ikhlas</h2>
+					<a class="next-story-link" href="https://www.baca-quran.id/stories/tentang-syukur/" target="_blank" rel="noopener">
+						<h2 class="cover-title">Tentang Syukur</h2>
 						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
 					</a>
 				</div>

--- a/src/tentang-tawakal/index.html
+++ b/src/tentang-tawakal/index.html
@@ -206,6 +206,17 @@
 			text-decoration: none;
 			color: inherit;
 		}
+
+		.home-link {
+			display: block;
+			margin-top: 1.5rem;
+			font-size: 0.8rem;
+			letter-spacing: 0.08em;
+			color: #fff;
+			text-decoration: underline;
+			text-underline-offset: 3px;
+			opacity: 0.75;
+		}
 	</style>
 
 	<script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -299,6 +310,7 @@
 						<h2 class="cover-title">Tentang Syukur</h2>
 						<p class="cover-sub">Ketuk untuk melanjutkan ↗</p>
 					</a>
+					<a class="home-link" href="https://www.baca-quran.id/stories/" target="_blank" rel="noopener">← Semua Cerita</a>
 				</div>
 			</div>
 		</amp-story-grid-layer>


### PR DESCRIPTION
## Summary

- The 2026-era stories all had their "next story" links pointing in the wrong direction — each pointed to the *newer* story instead of the *older* one
- Fixed all 8 affected pages so the chain follows newest-first publication order
- Also fixed `tentang-sabar` which was pointing to `tentang-syukur` (stale — `tentang-silaturahmi` is now the newest story)

**Correct chain after this fix:**
`silaturahmi → berbakti → jujur → taubat → ikhlas → tawakal → syukur → menuntut-ilmu → sedekah → sabar → silaturahmi`

| Story | Was | Now |
|---|---|---|
| silaturahmi | → menuntut-ilmu ❌ | → berbakti ✓ |
| berbakti | → silaturahmi ❌ | → jujur ✓ |
| jujur | → berbakti ❌ | → taubat ✓ |
| taubat | → jujur ❌ | → ikhlas ✓ |
| ikhlas | → taubat ❌ | → tawakal ✓ |
| tawakal | → ikhlas ❌ | → syukur ✓ |
| syukur | → tawakal ❌ | → menuntut-ilmu ✓ |
| sabar | → syukur ❌ | → silaturahmi ✓ |

## Test plan

- [ ] Open `tentang-silaturahmi` story and verify the last slide links to "Tentang Berbakti kepada Orang Tua"
- [ ] Open `tentang-berbakti-kepada-orang-tua` and verify it links to "Tentang Jujur"
- [ ] Walk the full chain to confirm all 10 stories link correctly in sequence
- [ ] Verify `tentang-sabar` loops back to `tentang-silaturahmi`

https://claude.ai/code/session_01Txq16EHoBaxdHmZvMf3p1a

---
_Generated by [Claude Code](https://claude.ai/code/session_01Txq16EHoBaxdHmZvMf3p1a)_